### PR TITLE
root: run lerna bootstrap upon npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/wmde/wikit.git"
   },
   "scripts": {
+    "postinstall": "lerna bootstrap",
     "test": "lerna run test"
   },
   "devDependencies": {


### PR DESCRIPTION
This ensures that package-level deps (and all of lerna's magic) are
installed if npm is used to install (or ci) via npm.

This way around the setup is more in line with most of our other
projects (npm as the entrypoint) and it is also possible to use lerna
(after npm installation) without having lerna installed globally.