### PR TITLE
tokens: lint .style-dictionary folder, too

### DIFF
--- a/tokens/.eslintignore
+++ b/tokens/.eslintignore
@@ -1,0 +1,1 @@
+!.style-dictionary/


### PR DESCRIPTION
Eslint ignores dot folders by default. We don't want that in this case.