### PR TITLE
docs: publish the documentation on github pages

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,27 @@
+name: Build and Deploy documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build:storybook
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/dist

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,8 @@
     "storybook": "start-storybook",
     "test": "npm-run-all test:*",
     "test:lint": "eslint .",
-    "fix": "npm run test:lint -- --fix"
+    "fix": "npm run test:lint -- --fix",
+    "build": "build-storybook -o dist"
   },
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "test": "lerna run test",
-    "storybook": "lerna run storybook --stream"
+    "storybook": "lerna run storybook --stream",
+    "build:storybook": "lerna run build --scope @wmde/wikit-docs"
   },
   "devDependencies": {
     "lerna": "^3.22.1"


### PR DESCRIPTION
This uses the gh-pages branch to host the built storybook.

It only excecutes on the master branch (I ran it w/o this filter to try)
and will need an overhaul when we want to host all the branches, but it
should give us results to demo now.

See
https://github.com/JamesIves/github-pages-deploy-action
https://wmde.github.io/wikit