### PR TITLE
Visualize color opacity tokens in Storybook

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12820,6 +12820,11 @@
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
       "dev": true
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",
     "@wmde/wikit-vue-components": "^0.0.0",
+    "traverse": "^0.6.6",
     "vue": "^2.6.11"
   },
   "bugs": {

--- a/docs/src/01-colors.stories.mdx
+++ b/docs/src/01-colors.stories.mdx
@@ -16,7 +16,7 @@ import { color } from '@wmde/wikit-tokens';
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
-            colors={[color.hex]}
+            colors={[color.value]}
         />
     ) )
 }
@@ -30,7 +30,7 @@ import { color } from '@wmde/wikit-tokens';
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
-            colors={[color.hex]}
+            colors={[color.value]}
         />
     ) )
 }
@@ -44,7 +44,7 @@ import { color } from '@wmde/wikit-tokens';
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
-            colors={[color.hex]}
+            colors={[color.value]}
         />
     ) )
 }
@@ -58,7 +58,7 @@ import { color } from '@wmde/wikit-tokens';
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
-            colors={[color.hex]}
+            colors={[color.value]}
         />
     ) )
 }

--- a/docs/src/01-colors.stories.mdx
+++ b/docs/src/01-colors.stories.mdx
@@ -3,7 +3,8 @@
 [//]: # (The list of available components can be found here:)
 [//]: # (https://github.com/storybookjs/storybook/blob/master/addons/docs/src/blocks/index.ts)
 import { Meta, Story, Preview, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
-import { colorBase, colorAccent, colorUtility, colorModifier } from './color.stories.js'
+import { getColorInfo } from './color.stories.js'
+import { color } from '@wmde/wikit-tokens';
 
 <Meta title="Design Tokens|Colors" />
 
@@ -11,7 +12,7 @@ import { colorBase, colorAccent, colorUtility, colorModifier } from './color.sto
 
 <ColorPalette>
 {
-    colorBase().map( ( color, index ) => (
+    getColorInfo( color.base ).map( ( color, index ) => (
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
@@ -25,7 +26,7 @@ import { colorBase, colorAccent, colorUtility, colorModifier } from './color.sto
 
 <ColorPalette>
 {
-    colorAccent().map( ( color, index ) => (
+    getColorInfo( color.accent ).map( ( color, index ) => (
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
@@ -39,7 +40,7 @@ import { colorBase, colorAccent, colorUtility, colorModifier } from './color.sto
 
 <ColorPalette>
 {
-    colorUtility().map( ( color, index ) => (
+    getColorInfo( color.utility ).map( ( color, index ) => (
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}
@@ -53,7 +54,7 @@ import { colorBase, colorAccent, colorUtility, colorModifier } from './color.sto
 
 <ColorPalette>
 {
-    colorModifier().map( ( color, index ) => (
+    getColorInfo( color.modifier ).map( ( color, index ) => (
         <ColorItem key={index}
             title={color.title}
             subtitle={color.subtitle}

--- a/docs/src/02-opacity.stories.mdx
+++ b/docs/src/02-opacity.stories.mdx
@@ -1,0 +1,24 @@
+import { color } from '@wmde/wikit-tokens';
+import { getColorInfo } from './color.stories.js'
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Design Tokens|Opacity" />
+
+## Opacity
+
+<table name="opacity" style={{ width: '100%' }}>
+    <tr>
+        <th>Name</th>
+        <th>Source</th>
+        <th>Value</th>
+    </tr>
+{
+    getColorInfo( color.opacity ).map( ( color, index ) => (
+        <tr key={index}>
+            <td>{color.title}</td>
+            <td>{color.subtitle}</td>
+            <td>{color.value}</td>
+        </tr>
+    ) )
+}
+</table>

--- a/docs/src/color.stories.js
+++ b/docs/src/color.stories.js
@@ -1,41 +1,23 @@
-import { color } from '@wmde/wikit-tokens';
+import traverse from 'traverse';
 
 /**
  * Gets specific set of information about every color in a subset of the color tokens
  *
- * @param {Object.<string, {name: string, value: string, original: any}>} colorType An object
+ * @param {Object} colorType A subtree of the tokens object containing only colors
  *   containing a certain subset of colors, e.g. base, accent, utility etc.
  * @return {{title: string, subtitle: string, hex: string}[]} An array of objects containing
  *   information about a certain color
  */
-function getColorInfo( colorType ) {
-	return Object.keys( colorType ).map( ( color ) => ( {
-		title: colorType[ color ].name,
-		subtitle: colorType[ color ].original.value.replace( /{|}|.value/gi, '' ),
-		hex: colorType[ color ].value,
-	} ) );
-}
+export function getColorInfo( colorType ) {
+	return traverse( colorType ).reduce( ( colors, node ) => {
+		if ( !node.original ) {
+			return colors;
+		}
 
-function flattenColorInfo( values ) {
-	let tokens = [];
-	for ( const topic in values ) {
-		tokens = tokens.concat( getColorInfo( values[ topic ] ) );
-	}
-	return tokens;
-}
-
-export function colorBase() {
-	return getColorInfo( color.base );
-}
-
-export function colorAccent() {
-	return getColorInfo( color.accent );
-}
-
-export function colorUtility() {
-	return flattenColorInfo( color.utility );
-}
-
-export function colorModifier() {
-	return flattenColorInfo( color.modifier );
+		return colors.concat( {
+			title: node.name,
+			subtitle: node.original.value.replace( /{|}|.value/gi, '' ),
+			hex: node.value,
+		} );
+	}, [] );
 }

--- a/docs/src/color.stories.js
+++ b/docs/src/color.stories.js
@@ -17,7 +17,7 @@ export function getColorInfo( colorType ) {
 		return colors.concat( {
 			title: node.name,
 			subtitle: node.original.value.replace( /{|}|.value/gi, '' ),
-			hex: node.value,
+			value: node.value,
 		} );
 	}, [] );
 }


### PR DESCRIPTION
- Rename 'hex' to 'value' because 'hex' does not make sense for color opacity values.
- The opacity is visualized in a native `html` `table`, because the docs addon does not seem to have a component of that sorts