### PR TITLE
docs: mark up opacity table correctly

### DIFF
--- a/docs/src/02-opacity.stories.mdx
+++ b/docs/src/02-opacity.stories.mdx
@@ -7,11 +7,14 @@ import { opacity } from '@wmde/wikit-tokens';
 ## Opacity
 
 <table name="opacity" style={{ width: '100%' }}>
-    <tr>
-        <th>Name</th>
-        <th>Source</th>
-        <th>Value</th>
-    </tr>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
 {
     flattenTokenTree( opacity ).map( ( opacity, index ) => (
         <tr key={index}>
@@ -21,4 +24,5 @@ import { opacity } from '@wmde/wikit-tokens';
         </tr>
     ) )
 }
+    </tbody>
 </table >


### PR DESCRIPTION
Add thead & tbody to stop storybook from complaining (browser console):

```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of
<table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM
tree generated by the browser.