### PR TITLE
docs: illustrate cursors

### DIFF
--- a/docs/src/03-cursors.stories.mdx
+++ b/docs/src/03-cursors.stories.mdx
@@ -1,0 +1,28 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { flattenTokenTree } from './lib/flattenTokenTree';
+import { cursor } from '@wmde/wikit-tokens';
+
+<Meta title="Design Tokens|Cursors" />
+
+## Cursors
+
+<table name="cursors" style={{ width: '100%' }}>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Value (hover to demo)</th>
+        </tr>
+    </thead>
+    <tbody>
+{
+    flattenTokenTree( cursor ).map( ( cursor ) => (
+        <tr key={ cursor.name } id={ cursor.name }>
+            <td><a href={ '#' + cursor.name }>{ cursor.name }</a></td>
+            <td>{ cursor.referencedTokens || '-' }</td>
+            <td style={{ cursor: cursor.value }}><pre>{ cursor.value }</pre></td>
+        </tr>
+    ) )
+}
+    </tbody>
+</table >


### PR DESCRIPTION
This
* shows the cursor tokens and values as a table
* illustrates the cursor upon hover of the value column
* renders ids and (self) links for the cursor tokens (not entirely sure where this is going yet)
* shows a lack of "source" token(s) as dash

Technically, this uses the token name to index the tr loop (key) - the
property is required by mdx, I assume to ensure that it can avoid
re-rendering things should the list change dyamically (like in Vue), and
the name is unique and stable by definition so lends itself better for
this use than the, by definition dynamic, index of the array.

We don't have that many representatives but there is a pattern emerging
e.g. between the cursors and the opacity story. Will look into how this
can be abstracted in a follow-up.

Bug: [T256861](https://phabricator.wikimedia.org/T256861)