### PR TITLE
Add font-family token demo

### DIFF
--- a/docs/src/04-font-family.stories.mdx
+++ b/docs/src/04-font-family.stories.mdx
@@ -1,0 +1,31 @@
+import { Meta, Typeset } from '@storybook/addon-docs/blocks';
+import { flattenTokenTree } from './lib/flattenTokenTree';
+import { font } from '@wmde/wikit-tokens';
+
+<Meta title="Design Tokens|Font family" />
+
+## Font family
+
+<table name="font-family" style={{ width: '100%' }}>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+{
+    flattenTokenTree( font.family ).map( ( { name, referencedTokens, value }, index ) => (
+        <tr key={index}>
+            <td>{name}</td>
+            <td>{referencedTokens || '-'}</td>
+            <td>
+                <p>{value}</p>
+                <Typeset fontSizes={[ '16px' ]} fontFamily={value} sampleText="Wiki" />
+            </td>
+        </tr>
+    ) )
+}
+    </tbody>
+</table >


### PR DESCRIPTION
Font family tokens illustrated, always with font size 16px as discussed with @SaiSan-WMDE in mattermost.

![Screenshot from 2020-07-02 12-50-18](https://user-images.githubusercontent.com/453024/86350302-c2d86580-bc62-11ea-8b18-ff79de9feb6a.png)
