### PR TITLE
lerna: hoist deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/wmde/wikit.git"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap --hoist",
     "test": "lerna run test",
     "storybook": "lerna run storybook --stream",
     "build:storybook": "lerna run build --scope @wmde/wikit-docs"


### PR DESCRIPTION
This should make the leaf deps available on the root folder.

Maybe this will overcome the challenges we see in
https://github.com/wmde/wikit/pull/34 where the Chromatic github action
seems to struggle to identify which storybook version it is supposed to
do its thing for because storybook is only installed in a sub-package
(docs), not the root.

See
https://github.com/lerna/lerna/tree/master/commands/bootstrap#--hoist-glob

Bug: T256864