### PR TITLE
TokenTable: fix token links

### DIFF
--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -18,7 +18,7 @@ export function TokenTable( { tokens, valueCell } ) {
 			{
 				flattenTokenTree( tokens ).map( ( { name, referencedTokens, value } ) => (
 					<tr key={name} id={name}>
-						<td><a href={'#' + name}>{name}</a></td>
+						<td><components.a href={'#' + name}>{name}</components.a></td>
 						<td>{referencedTokens || '-'}</td>
 						<td>{renderValue( value )}</td>
 					</tr>


### PR DESCRIPTION
This applies the default link styles and behavior from storybook to token links and prevents them from opening the story frame instead of navigating to the token anchor within the storybook.