### PR TITLE
docs: align TokenTable with ColorPallete

### DIFF
--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -10,16 +10,22 @@ export function TokenTable( { tokens, valueCell } ) {
 			<thead>
 			<tr>
 				<th>Name</th>
-				<th>Source</th>
-				<th>Value</th>
+				<th>Value / Swatch</th>
 			</tr>
 			</thead>
 			<tbody>
 			{
 				flattenTokenTree( tokens ).map( ( { name, referencedTokens, value } ) => (
 					<tr key={name} id={name}>
-						<td><components.a href={'#' + name}>🔗</components.a> {name}</td>
-						<td>{referencedTokens || '-'}</td>
+						<td>
+							<components.a href={'#' + name}>🔗</components.a>
+							&nbsp;<strong>{name}</strong>
+							<br />
+							{referencedTokens ?
+								<span title="value influenced by">{referencedTokens}</span> :
+								<i>primary value</i>
+							}
+						</td>
 						<td>{renderValue( value )}</td>
 					</tr>
 				) )


### PR DESCRIPTION
Somewhat takes away from the semantics, but aligns those token pages visually 
and creates a bit more room for the presenters. Also somewhat explains to the
users the difference between primary values and values influenced by other
tokens.

Should probably recycle the very elements if we really mean to achieve
identical layout.

See
https://github.com/storybookjs/storybook/blob/b6136e1539c85d253504391a7d3f65e2c1239143/lib/components/src/blocks/ColorPalette.tsx#L170