### PR TITLE
docs: reflect clicked anchors in browser URL

### DIFF
--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { flattenTokenTree } from './flattenTokenTree';
 import { components } from '@storybook/components/dist/typography/DocumentFormatting';
+import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx';
 
 export function TokenTable( { tokens, valueCell } ) {
 	const renderValue = ( value ) => valueCell ? valueCell( value ) : <pre>{value}</pre>;
@@ -18,7 +19,7 @@ export function TokenTable( { tokens, valueCell } ) {
 				flattenTokenTree( tokens ).map( ( { name, referencedTokens, value } ) => (
 					<tr key={name} id={name}>
 						<td>
-							<components.a href={'#' + name}>🔗</components.a>
+							<AnchorMdx href={'#' + name}>🔗</AnchorMdx>
 							&nbsp;<strong>{name}</strong>
 							<br />
 							{referencedTokens ?


### PR DESCRIPTION
So that the deep links can be used to communicate between people.

Bug: [T256861](https://phabricator.wikimedia.org/T256861) (mentioned there)

There was a bug report of sorts in https://phabricator.wikimedia.org/T256861#6276737 and this hopefully solves it.