### PR TITLE
docs: alternative ways to present tokens

### DIFF
--- a/docs/src/00-dashboard.stories.mdx
+++ b/docs/src/00-dashboard.stories.mdx
@@ -1,0 +1,6 @@
+import * as tokens from '@wmde/wikit-tokens';
+import { Dashboard } from './lib/Dashboard';
+
+<Meta title="Design Tokens|+ dashboard" />
+
+<Dashboard tokens={ tokens } />

--- a/docs/src/14-all.stories.mdx
+++ b/docs/src/14-all.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta, Typeset } from '@storybook/addon-docs/blocks';
+import { TokenTableAll } from './lib/TokenTableAll';
+import * as tokens from '@wmde/wikit-tokens';
+
+<Meta title="Design Tokens|all" />
+
+## All
+
+<TokenTableAll tokens={tokens} />

--- a/docs/src/lib/Dashboard.jsx
+++ b/docs/src/lib/Dashboard.jsx
@@ -1,0 +1,80 @@
+import traverse from 'traverse';
+import { TokenTableAll } from './TokenTableAll';
+import React from 'react';
+import styles from './../styles/dashboard.css';
+
+/**
+ * TODO unify with flattenTokenTree
+ */
+function flatten( nestedTokens ) {
+	return traverse( nestedTokens ).reduce( ( tokens, node ) => {
+		if ( !node.original ) {
+			return tokens;
+		}
+
+		return tokens.concat( {
+			name: node.name,
+			referencedTokens: node.attributes.tokens,
+			value: node.value,
+		} );
+	}, [] );
+}
+
+function sortTokensByName( a, b ) {
+	return a.name > b.name ? 1 : a.name < b.name ? -1 : 0;
+}
+
+function globalsEndemic( tokens ) {
+	return flatten( tokens )
+		.filter( ( token ) => !token.referencedTokens.length )
+		.sort( sortTokensByName );
+}
+
+function globalsWmfInspired( tokens ) {
+	return flatten( tokens )
+		.filter( ( token ) => {
+			return (
+				token.referencedTokens.length === 1
+				&&
+				token.referencedTokens[0].match( /^wmf-.+/ )
+			);
+		} )
+		.sort( sortTokensByName );
+}
+
+function getOtherTokens( tokens, globals ) {
+	const aliases = flatten( tokens );
+	const globalNames = globals.map( ( token ) => token.name );
+
+	return aliases
+		.filter( ( token ) => !globalNames.includes( token.name ) )
+		.sort( sortTokensByName );
+}
+
+export function Dashboard( { tokens } ) {
+	const wmfInspired = globalsWmfInspired( tokens ),
+		endemic = globalsEndemic( tokens ),
+		globalsCount = endemic.length + wmfInspired.length,
+		otherTokens = getOtherTokens( tokens, [ ...wmfInspired, ...endemic ] );
+
+	return (
+		<div className="dashboard">
+			<h2>Global Tokens ({ globalsCount })</h2>
+
+			<h3>WMF-inspired ({ wmfInspired.length })</h3>
+			<div className="scrollit">
+				<TokenTableAll tokens={ wmfInspired } />
+			</div>
+
+			<h3>Endemic ({ endemic.length })</h3>
+			<div className="scrollit">
+				<TokenTableAll tokens={ endemic } />
+			</div>
+
+			<h2>Aliases ({ otherTokens.length })</h2>
+			<div className="scrollit">
+				<TokenTableAll tokens={ otherTokens } />
+			</div>
+		</div>
+	)
+}

--- a/docs/src/lib/TokenTableAll.jsx
+++ b/docs/src/lib/TokenTableAll.jsx
@@ -63,8 +63,9 @@ function render( token ) {
 }
 
 export function TokenTableAll( { tokens } ) {
+	const flatTokens = Array.isArray( tokens ) ? tokens : flattenTokenTree( tokens );
 	return (
-		<components.table style={{ width: '100%' }}>
+		<components.table className="dashboardTable" style={{ width: '100%' }}>
 			<thead>
 			<tr>
 				<th>Name</th>
@@ -73,13 +74,13 @@ export function TokenTableAll( { tokens } ) {
 			</thead>
 			<tbody>
 			{
-				flattenTokenTree( tokens ).map( ( token ) => (
+				flatTokens.map( ( token ) => (
 					<tr key={ token.name } id={ token.name }>
 						<td>
 							<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
 							&nbsp;<strong>{ token.name }</strong>
 							<br />
-							{ token.referencedTokens ?
+							{ token.referencedTokens.length ?
 								<span title="value influenced by">{ token.referencedTokens }</span> :
 								<i>primary value</i>
 							}

--- a/docs/src/lib/TokenTableAll.jsx
+++ b/docs/src/lib/TokenTableAll.jsx
@@ -10,38 +10,56 @@ import FontSize from './presenters/FontSize';
 import FontFamily from './presenters/FontFamily';
 import Transition from './presenters/Transition';
 import Cursor from './presenters/Cursor';
+import Default from './presenters/Default';
+
+/**
+ * Is a token used to denote another (CSS) property,
+ * e.g. "transition-property-box-shadow" = "box-shadow"
+ *
+ * @param name
+ * @return {boolean}
+ */
+function isPropertyToken( name ) {
+	return !!name.match(/\bproperty\b/);
+}
 
 function render( token ) {
-	const value = token.value;
-	if ( token.name.match(/\bcolor\b/) ) {
-		return <ColorItem key={ token.name }
-			title={ token.name }
+	const name = token.name;
+
+	if ( isPropertyToken( name ) ) {
+		return <Default token={ token } />;
+	}
+
+	if ( name.match(/\bcolor\b/) ) {
+		return <ColorItem key={ name }
+			title={ name }
 			subtitle={ token.referencedTokens }
 			colors={[ token.value ]}
 		/>;
 	}
-	else if ( token.name.match( /\bfont-family\b/ ) ) {
+	else if ( name.match( /\bfont-family\b/ ) ) {
 		return <FontFamily token={ token } />;
 	}
-	else if ( token.name.match( /\bfont-size\b/ ) ) {
+	else if ( name.match( /\bfont-size\b/ ) ) {
 		return <FontSize token={ token } />;
 	}
-	else if ( token.name.match( /\bfont-weight\b/ ) ) {
+	else if ( name.match( /\bfont-weight\b/ ) ) {
 		return <FontWeight token={ token } />;
 	}
-	else if ( token.name.match( /\bline-height\b/ ) ) {
+	else if ( name.match( /\bline-height\b/ ) ) {
 		return <LineHeight token={ token } />
 	}
-	else if ( token.name.match( /\bbox-shadow\b/ ) ) {
+	else if ( name.match( /\bbox-shadow\b/ ) ) {
 		return <Shadows token={ token } />
 	}
-	else if ( token.name.match( /\btransition\b/ ) ) {
+	else if ( name.match( /\btransition\b/ ) ) {
 		return <Transition token={ token } />
 	}
-	else if ( token.name.match( /\bcursor\b/ ) ) {
+	else if ( name.match( /\bcursor\b/ ) ) {
 		return <Cursor token={ token } />
 	}
-	return <pre>{value}</pre>;
+
+	return <Default token={ token } />;
 }
 
 export function TokenTableAll( { tokens } ) {

--- a/docs/src/lib/TokenTableAll.jsx
+++ b/docs/src/lib/TokenTableAll.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { flattenTokenTree } from './flattenTokenTree';
+import { components } from '@storybook/components/dist/typography/DocumentFormatting';
+import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx';
+import { ColorItem } from '@storybook/addon-docs/blocks';
+import Shadows from './presenters/Shadows';
+import LineHeight from './presenters/LineHeight';
+import FontWeight from './presenters/FontWeight';
+import FontSize from './presenters/FontSize';
+import FontFamily from './presenters/FontFamily';
+import Transition from './presenters/Transition';
+import Cursor from './presenters/Cursor';
+
+function render( token ) {
+	const value = token.value;
+	if ( token.name.match(/\bcolor\b/) ) {
+		return <ColorItem key={ token.name }
+			title={ token.name }
+			subtitle={ token.referencedTokens }
+			colors={[ token.value ]}
+		/>;
+	}
+	else if ( token.name.match( /\bfont-family\b/ ) ) {
+		return <FontFamily token={ token } />;
+	}
+	else if ( token.name.match( /\bfont-size\b/ ) ) {
+		return <FontSize token={ token } />;
+	}
+	else if ( token.name.match( /\bfont-weight\b/ ) ) {
+		return <FontWeight token={ token } />;
+	}
+	else if ( token.name.match( /\bline-height\b/ ) ) {
+		return <LineHeight token={ token } />
+	}
+	else if ( token.name.match( /\bbox-shadow\b/ ) ) {
+		return <Shadows token={ token } />
+	}
+	else if ( token.name.match( /\btransition\b/ ) ) {
+		return <Transition token={ token } />
+	}
+	else if ( token.name.match( /\bcursor\b/ ) ) {
+		return <Cursor token={ token } />
+	}
+	return <pre>{value}</pre>;
+}
+
+export function TokenTableAll( { tokens } ) {
+	return (
+		<components.table style={{ width: '100%' }}>
+			<thead>
+			<tr>
+				<th>Name</th>
+				<th>Value / Swatch</th>
+			</tr>
+			</thead>
+			<tbody>
+			{
+				flattenTokenTree( tokens ).map( ( token ) => (
+					<tr key={ token.name } id={ token.name }>
+						<td>
+							<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
+							&nbsp;<strong>{ token.name }</strong>
+							<br />
+							{ token.referencedTokens ?
+								<span title="value influenced by">{ token.referencedTokens }</span> :
+								<i>primary value</i>
+							}
+						</td>
+						<td>{ render( token ) }</td>
+					</tr>
+				) )
+			}
+			</tbody>
+		</components.table>
+	);
+}

--- a/docs/src/lib/presenters/Cursor.jsx
+++ b/docs/src/lib/presenters/Cursor.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div style={{ cursor: token.value }}>
+			<pre>{ token.value }</pre>
+			<p>(hover to demo)</p>
+		</div>
+	);
+}
+

--- a/docs/src/lib/presenters/Default.jsx
+++ b/docs/src/lib/presenters/Default.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ( { token } ) {
+	return <pre>{ token.value }</pre>;
+}

--- a/docs/src/lib/presenters/FontFamily.jsx
+++ b/docs/src/lib/presenters/FontFamily.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ '16px' ]}
+			fontFamily={ token.value }
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/FontSize.jsx
+++ b/docs/src/lib/presenters/FontSize.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ token.value ]}
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/FontWeight.jsx
+++ b/docs/src/lib/presenters/FontWeight.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ '16px' ]}
+			fontWeight={ token.value }
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/LineHeight.jsx
+++ b/docs/src/lib/presenters/LineHeight.jsx
@@ -1,0 +1,13 @@
+import styles from './../../styles/line-height.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div>
+			<pre>{ token.value }</pre>
+			<div className='lineHeight' style={{ lineHeight: token.value }}>
+				The quick brown fox jumps over the lazy dog
+			</div>
+		</div>
+	);
+}

--- a/docs/src/lib/presenters/Shadows.jsx
+++ b/docs/src/lib/presenters/Shadows.jsx
@@ -1,0 +1,10 @@
+import styles from './../../styles/shadows.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div className="shadows" style={{ boxShadow: token.value }}>
+			<pre>{ token.value }</pre>
+		</div>
+	);
+}

--- a/docs/src/lib/presenters/Transition.jsx
+++ b/docs/src/lib/presenters/Transition.jsx
@@ -1,0 +1,11 @@
+import styles from './../../styles/transition.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div>
+			<pre>{ token.value }</pre>
+			<div className="transition" style={{ transitionDuration: token.value }}/>
+		</div>
+	);
+}

--- a/docs/src/styles/dashboard.css
+++ b/docs/src/styles/dashboard.css
@@ -1,0 +1,6 @@
+.dashboard .scrollit {
+    display: block;
+    height: 300px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}

--- a/docs/src/styles/shadows.css
+++ b/docs/src/styles/shadows.css
@@ -1,0 +1,6 @@
+.shadows {
+    height: 80px;
+    width: 150px;
+    background-color: #FFE599;
+    padding: 20px 10px;
+}


### PR DESCRIPTION
Adds
* a page showing all tokens, inferring their presenter
* a dashboard grouping tokens into the categories globals & aliases (all others, in fact)