### PR TITLE
docs: infer presenter from token name

### DIFF
--- a/docs/src/01-colors.stories.mdx
+++ b/docs/src/01-colors.stories.mdx
@@ -3,77 +3,27 @@
 [//]: # (The list of available components can be found here:)
 [//]: # (https://github.com/storybookjs/storybook/blob/master/addons/docs/src/blocks/index.ts)
 import { Meta, Story, Preview, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
-import { flattenTokenTree } from './lib/flattenTokenTree'
+import { TokenTable } from './lib/TokenTable';
 import { color } from '@wmde/wikit-tokens';
 
 <Meta title="Design Tokens|Colors" />
 
 ## Base
 
-<ColorPalette>
-{
-    flattenTokenTree( color.base ).map( ( color, index ) => (
-        <ColorItem key={index}
-            title={color.name}
-            subtitle={color.referencedTokens}
-            colors={[color.value]}
-        />
-    ) )
-}
-</ColorPalette>
+<TokenTable tokens={color.base} />
 
 ## Accent
 
-<ColorPalette>
-{
-    flattenTokenTree( color.accent ).map( ( color, index ) => (
-        <ColorItem key={index}
-            title={color.name}
-            subtitle={color.referencedTokens}
-            colors={[color.value]}
-        />
-    ) )
-}
-</ColorPalette>
+<TokenTable tokens={color.accent} />
 
 ## Utility
 
-<ColorPalette>
-{
-    flattenTokenTree( color.utility ).map( ( color, index ) => (
-        <ColorItem key={index}
-            title={color.name}
-            subtitle={color.referencedTokens}
-            colors={[color.value]}
-        />
-    ) )
-}
-</ColorPalette>
+<TokenTable tokens={color.utility} />
 
 ## Modifier
 
-<ColorPalette>
-{
-    flattenTokenTree( color.modifier ).map( ( color, index ) => (
-        <ColorItem key={index}
-            title={color.name}
-            subtitle={color.referencedTokens}
-            colors={[color.value]}
-        />
-    ) )
-}
-</ColorPalette>
+<TokenTable tokens={color.modifier} />
 
 ## Interaction
 
-<ColorPalette>
-{
-    flattenTokenTree( color.interaction ).map( ( color, index ) => (
-        <ColorItem key={index}
-            title={color.name}
-            subtitle={color.referencedTokens}
-            colors={[color.value]}
-        />
-    ) )
-}
-</ColorPalette>
+<TokenTable tokens={color.interaction} />

--- a/docs/src/04-font-family.stories.mdx
+++ b/docs/src/04-font-family.stories.mdx
@@ -6,16 +6,4 @@ import { TokenTable } from './lib/TokenTable';
 
 ## Font family
 
-<TokenTable
-    tokens={font.family}
-    valueCell={( value ) => (
-        <div>
-            <p>{value}</p>
-            <Typeset
-                fontSizes={[ '16px' ]}
-                fontFamily={value}
-                sampleText="The quick brown fox jumps over the lazy dog"
-            />
-        </div>
-    )}
-/>
+<TokenTable tokens={font.family} />

--- a/docs/src/05-font-size.stories.mdx
+++ b/docs/src/05-font-size.stories.mdx
@@ -6,12 +6,4 @@ import { dimension } from '@wmde/wikit-tokens';
 
 ## Font size
 
-<TokenTable
-    tokens={dimension.font.size}
-    valueCell={( value ) => (
-        <Typeset
-            fontSizes={[ value ]}
-            sampleText="The quick brown fox jumps over the lazy dog"
-        />
-    )}
-/>
+<TokenTable tokens={dimension.font.size} />

--- a/docs/src/06-font-weight.stories.mdx
+++ b/docs/src/06-font-weight.stories.mdx
@@ -6,16 +6,4 @@ import { font } from '@wmde/wikit-tokens';
 
 ## Font weight
 
-<TokenTable
-    tokens={font.weight}
-    valueCell={( value ) => (
-        <div>
-            <p>{value}</p>
-            <Typeset
-                fontSizes={[ '16px' ]}
-                fontWeight={value}
-                sampleText="The quick brown fox jumps over the lazy dog"
-            />
-        </div>
-    )}
-/>
+<TokenTable tokens={font.weight} />

--- a/docs/src/07-line-height.stories.mdx
+++ b/docs/src/07-line-height.stories.mdx
@@ -7,14 +7,4 @@ import styles from './styles/line-height.css';
 
 ## Line-height
 
-<TokenTable
-    tokens={font[ 'line-height' ]}
-    valueCell={( value ) => (
-        <div>
-            <pre>{ value }</pre>
-            <div className='lineHeight' style={{ lineHeight: value }}>
-                The quick brown fox jumps over the lazy dog
-            </div>
-        </div>
-    )}
-/>
+<TokenTable tokens={font[ 'line-height' ]} />

--- a/docs/src/10-shadows.stories.mdx
+++ b/docs/src/10-shadows.stories.mdx
@@ -6,18 +6,4 @@ import * as tokens from '@wmde/wikit-tokens';
 
 ## Shadows
 
-<TokenTable
-    tokens={tokens['box-shadow']} 
-    valueCell={( value ) => (
-            <div style={{
-                height: '80px',
-                width: '150px',
-                boxShadow: value,
-                backgroundColor: '#FFE599',
-                padding: '20px 10px'
-            }}>
-                <pre>{ value }</pre>
-            </div>
-            
-        )}
-/>
+<TokenTable tokens={tokens['box-shadow']} />

--- a/docs/src/11-transition.stories.mdx
+++ b/docs/src/11-transition.stories.mdx
@@ -9,15 +9,7 @@ import styles from './styles/transition.css';
 
 ### Duration
 
-<TokenTable
-    tokens={transition.duration}
-    valueCell={( value ) => (
-        <div>
-            <pre>{ value }</pre>
-            <div class="transition" style={{ transitionDuration: value }} />
-        </div>
-    )}
-/>
+<TokenTable tokens={transition.duration} />
 
 ### Property
 

--- a/docs/src/12-cursors.stories.mdx
+++ b/docs/src/12-cursors.stories.mdx
@@ -6,12 +6,4 @@ import { cursor } from '@wmde/wikit-tokens';
 
 ## Cursors
 
-<TokenTable
-    tokens={cursor}
-    valueCell={( value ) => (
-        <div style={{ cursor: value }}>
-            <pre>{ value }</pre>
-            <p>(hover to demo)</p>
-        </div>
-    )}
-/>
+<TokenTable tokens={cursor} />

--- a/docs/src/lib/TokenPresenter.jsx
+++ b/docs/src/lib/TokenPresenter.jsx
@@ -6,7 +6,6 @@ import FontSize from './presenters/FontSize';
 import FontFamily from './presenters/FontFamily';
 import Transition from './presenters/Transition';
 import Cursor from './presenters/Cursor';
-import Default from './presenters/Default';
 import Color from './presenters/Color';
 
 /**
@@ -24,7 +23,7 @@ export function TokenPresenter( { token } ) {
 	const name = token.name;
 
 	if ( isPropertyToken( name ) ) {
-		return <Default token={ token } />;
+		return null;
 	}
 
 	if ( name.match(/\bcolor\b/) ) {
@@ -52,5 +51,5 @@ export function TokenPresenter( { token } ) {
 		return <Cursor token={ token } />
 	}
 
-	return <Default token={ token } />;
+	return null;
 }

--- a/docs/src/lib/TokenPresenter.jsx
+++ b/docs/src/lib/TokenPresenter.jsx
@@ -7,7 +7,7 @@ import FontFamily from './presenters/FontFamily';
 import Transition from './presenters/Transition';
 import Cursor from './presenters/Cursor';
 import Default from './presenters/Default';
-import { ColorItem } from '@storybook/addon-docs/blocks';
+import Color from './presenters/Color';
 
 /**
  * Is a token used to denote another (CSS) property,
@@ -28,11 +28,7 @@ export function TokenPresenter( { token } ) {
 	}
 
 	if ( name.match(/\bcolor\b/) ) {
-		return <ColorItem key={ name }
-			title={ name }
-			subtitle={ token.referencedTokens }
-			colors={[ token.value ]}
-		/>;
+		return <Color token={ token } />;
 	}
 	else if ( name.match( /\bfont-family\b/ ) ) {
 		return <FontFamily token={ token } />;

--- a/docs/src/lib/TokenPresenter.jsx
+++ b/docs/src/lib/TokenPresenter.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Shadows from './presenters/Shadows';
+import LineHeight from './presenters/LineHeight';
+import FontWeight from './presenters/FontWeight';
+import FontSize from './presenters/FontSize';
+import FontFamily from './presenters/FontFamily';
+import Transition from './presenters/Transition';
+import Cursor from './presenters/Cursor';
+import Default from './presenters/Default';
+import { ColorItem } from '@storybook/addon-docs/blocks';
+
+/**
+ * Is a token used to denote another (CSS) property,
+ * e.g. "transition-property-box-shadow" = "box-shadow"
+ *
+ * @param name
+ * @return {boolean}
+ */
+function isPropertyToken( name ) {
+	return !!name.match(/\bproperty\b/);
+}
+
+export function TokenPresenter( { token } ) {
+	const name = token.name;
+
+	if ( isPropertyToken( name ) ) {
+		return <Default token={ token } />;
+	}
+
+	if ( name.match(/\bcolor\b/) ) {
+		return <ColorItem key={ name }
+			title={ name }
+			subtitle={ token.referencedTokens }
+			colors={[ token.value ]}
+		/>;
+	}
+	else if ( name.match( /\bfont-family\b/ ) ) {
+		return <FontFamily token={ token } />;
+	}
+	else if ( name.match( /\bfont-size\b/ ) ) {
+		return <FontSize token={ token } />;
+	}
+	else if ( name.match( /\bfont-weight\b/ ) ) {
+		return <FontWeight token={ token } />;
+	}
+	else if ( name.match( /\bline-height\b/ ) ) {
+		return <LineHeight token={ token } />
+	}
+	else if ( name.match( /\bbox-shadow\b/ ) ) {
+		return <Shadows token={ token } />
+	}
+	else if ( name.match( /\btransition\b/ ) ) {
+		return <Transition token={ token } />
+	}
+	else if ( name.match( /\bcursor\b/ ) ) {
+		return <Cursor token={ token } />
+	}
+
+	return <Default token={ token } />;
+}

--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { flattenTokenTree } from './flattenTokenTree';
+import { TokenPresenter } from './TokenPresenter';
 import { components } from '@storybook/components/dist/typography/DocumentFormatting';
 import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx';
 
-export function TokenTable( { tokens, valueCell } ) {
-	const renderValue = ( value ) => valueCell ? valueCell( value ) : <pre>{value}</pre>;
-
+export function TokenTable( { tokens } ) {
 	return (
 		<components.table style={{ width: '100%' }}>
 			<thead>
@@ -16,18 +15,20 @@ export function TokenTable( { tokens, valueCell } ) {
 			</thead>
 			<tbody>
 			{
-				flattenTokenTree( tokens ).map( ( { name, referencedTokens, value } ) => (
-					<tr key={name} id={name}>
+				flattenTokenTree( tokens ).map( ( token ) => (
+					<tr key={ token.name } id={ token.name }>
 						<td>
-							<AnchorMdx href={'#' + name}>🔗</AnchorMdx>
-							&nbsp;<strong>{name}</strong>
+							<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
+							&nbsp;<strong>{ token.name }</strong>
 							<br />
-							{referencedTokens ?
-								<span title="value influenced by">{referencedTokens}</span> :
+							{ token.referencedTokens ?
+								<span title="value influenced by">{ token.referencedTokens }</span> :
 								<i>primary value</i>
 							}
 						</td>
-						<td>{renderValue( value )}</td>
+						<td>
+							<TokenPresenter token={ token } />
+						</td>
 					</tr>
 				) )
 			}

--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -27,6 +27,7 @@ export function TokenTable( { tokens } ) {
 							}
 						</td>
 						<td>
+							<pre>{ token.value }</pre>
 							<TokenPresenter token={ token } />
 						</td>
 					</tr>

--- a/docs/src/lib/presenters/Color.jsx
+++ b/docs/src/lib/presenters/Color.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './../../styles/color.css';
+
+/**
+ * Inspired by { ColorItem } from '@storybook/addon-docs/blocks';
+ * Unfortunately its swatch is not usable independently
+ */
+export default function ( { token } ) {
+	return (
+		<div>
+			<div className='color' style={{ backgroundColor: token.value }} />
+			<pre>{ token.value }</pre>
+		</div>
+	);
+}
+

--- a/docs/src/lib/presenters/Color.jsx
+++ b/docs/src/lib/presenters/Color.jsx
@@ -7,10 +7,7 @@ import styles from './../../styles/color.css';
  */
 export default function ( { token } ) {
 	return (
-		<div>
-			<div className='color' style={{ backgroundColor: token.value }} />
-			<pre>{ token.value }</pre>
-		</div>
+		<div className='color' style={{ backgroundColor: token.value }} />
 	);
 }
 

--- a/docs/src/lib/presenters/Cursor.jsx
+++ b/docs/src/lib/presenters/Cursor.jsx
@@ -2,10 +2,7 @@ import React from 'react';
 
 export default function ( { token } ) {
 	return (
-		<div style={{ cursor: token.value }}>
-			<pre>{ token.value }</pre>
-			<p>(hover to demo)</p>
-		</div>
+		<p style={{ cursor: token.value }}>(hover to demo)</p>
 	);
 }
 

--- a/docs/src/lib/presenters/Cursor.jsx
+++ b/docs/src/lib/presenters/Cursor.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div style={{ cursor: token.value }}>
+			<pre>{ token.value }</pre>
+			<p>(hover to demo)</p>
+		</div>
+	);
+}
+

--- a/docs/src/lib/presenters/Default.jsx
+++ b/docs/src/lib/presenters/Default.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function ( { token } ) {
-	return <pre>{ token.value }</pre>;
-}

--- a/docs/src/lib/presenters/Default.jsx
+++ b/docs/src/lib/presenters/Default.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ( { token } ) {
+	return <pre>{ token.value }</pre>;
+}

--- a/docs/src/lib/presenters/FontFamily.jsx
+++ b/docs/src/lib/presenters/FontFamily.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ '16px' ]}
+			fontFamily={ token.value }
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/FontSize.jsx
+++ b/docs/src/lib/presenters/FontSize.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ token.value ]}
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/FontWeight.jsx
+++ b/docs/src/lib/presenters/FontWeight.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typeset } from '@storybook/addon-docs/blocks';
+
+export default function ( { token } ) {
+	return (
+		<Typeset
+			fontSizes={[ '16px' ]}
+			fontWeight={ token.value }
+			sampleText="The quick brown fox jumps over the lazy dog"
+		/>
+	);
+}

--- a/docs/src/lib/presenters/LineHeight.jsx
+++ b/docs/src/lib/presenters/LineHeight.jsx
@@ -1,0 +1,13 @@
+import styles from './../../styles/line-height.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div>
+			<pre>{ token.value }</pre>
+			<div className='lineHeight' style={{ lineHeight: token.value }}>
+				The quick brown fox jumps over the lazy dog
+			</div>
+		</div>
+	);
+}

--- a/docs/src/lib/presenters/LineHeight.jsx
+++ b/docs/src/lib/presenters/LineHeight.jsx
@@ -3,11 +3,8 @@ import React from 'react';
 
 export default function ( { token } ) {
 	return (
-		<div>
-			<pre>{ token.value }</pre>
-			<div className='lineHeight' style={{ lineHeight: token.value }}>
-				The quick brown fox jumps over the lazy dog
-			</div>
+		<div className='lineHeight' style={{ lineHeight: token.value }}>
+			The quick brown fox jumps over the lazy dog
 		</div>
 	);
 }

--- a/docs/src/lib/presenters/Shadows.jsx
+++ b/docs/src/lib/presenters/Shadows.jsx
@@ -1,0 +1,10 @@
+import styles from './../../styles/shadows.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div className="shadows" style={{ boxShadow: token.value }}>
+			<pre>{ token.value }</pre>
+		</div>
+	);
+}

--- a/docs/src/lib/presenters/Transition.jsx
+++ b/docs/src/lib/presenters/Transition.jsx
@@ -1,0 +1,11 @@
+import styles from './../../styles/transition.css';
+import React from 'react';
+
+export default function ( { token } ) {
+	return (
+		<div>
+			<pre>{ token.value }</pre>
+			<div className="transition" style={{ transitionDuration: token.value }}/>
+		</div>
+	);
+}

--- a/docs/src/lib/presenters/Transition.jsx
+++ b/docs/src/lib/presenters/Transition.jsx
@@ -3,9 +3,6 @@ import React from 'react';
 
 export default function ( { token } ) {
 	return (
-		<div>
-			<pre>{ token.value }</pre>
-			<div className="transition" style={{ transitionDuration: token.value }}/>
-		</div>
+		<div className="transition" style={{ transitionDuration: token.value }}/>
 	);
 }

--- a/docs/src/styles/color.css
+++ b/docs/src/styles/color.css
@@ -1,0 +1,12 @@
+/**
+ * Illustrate a color.
+ * Apply to an element, pass a custom background-color.
+ */
+.color {
+    border-radius: 4px;
+    box-shadow: rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    height: 50px;
+    width: 300px;
+    margin-bottom: 5px;
+}

--- a/docs/src/styles/shadows.css
+++ b/docs/src/styles/shadows.css
@@ -1,0 +1,6 @@
+.shadows {
+    height: 80px;
+    width: 150px;
+    background-color: #FFE599;
+    padding: 20px 10px;
+}


### PR DESCRIPTION
This allows to show tokens without deciding for one specific way of
presenting all of them (e.g. in a collection of many different ones).

Unfortunately, ColorItem's swatch is not usable independently and we
want to achieve identical style across tokens and also consistently get the deeplink
functionality, so we reimplement the color swatch.

Bug: [T256024](https://phabricator.wikimedia.org/T256024)