### PR TITLE
docs: style referenced tokens

### DIFF
--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -3,10 +3,11 @@ import { flattenTokenTree } from './flattenTokenTree';
 import { TokenPresenter } from './TokenPresenter';
 import { components } from '@storybook/components/dist/typography/DocumentFormatting';
 import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx';
+import styles from './../styles/token-table.css';
 
 export function TokenTable( { tokens } ) {
 	return (
-		<components.table style={{ width: '100%' }}>
+		<components.table className='token-table' style={{ width: '100%' }}>
 			<thead>
 			<tr>
 				<th>Name</th>
@@ -20,11 +21,9 @@ export function TokenTable( { tokens } ) {
 						<td>
 							<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
 							&nbsp;<strong>{ token.name }</strong>
-							<br />
-							{ token.referencedTokens ?
-								<span title="value influenced by">{ token.referencedTokens }</span> :
-								<i>primary value</i>
-							}
+							<div className="referenced-tokens" title="value influenced by">
+								{ token.referencedTokens || '—' }
+							</div>
 						</td>
 						<td>
 							<pre>{ token.value }</pre>

--- a/docs/src/styles/token-table.css
+++ b/docs/src/styles/token-table.css
@@ -1,0 +1,3 @@
+.token-table .referenced-tokens {
+    color: rgba(51, 51, 51, 0.8);
+}


### PR DESCRIPTION
Create UX-desired style for referenced tokens in TokenTable.
Unfortunately the specification only happened in chat.

Also replace the "primary value" information and custom style with a
dash because that apparently is more clear.

Bug: [T256024](https://phabricator.wikimedia.org/T256024)