### PR TITLE
correct wrong border color value

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -292,7 +292,7 @@
                     "value": "{color.base.80.value}"
                 },
                 "focus": {
-                    "value": "{color.base.100.value}"
+                    "value": "{color.accent.50.value}"
                 }
             },
             "destructive":{


### PR DESCRIPTION
Visualization helped detect that an incorrect value had been provided for the token border.color.neutral.focus