### PR TITLE
modify width and height of the Shadows presenter

### DIFF
--- a/docs/src/lib/presenters/Shadows.css
+++ b/docs/src/lib/presenters/Shadows.css
@@ -1,5 +1,5 @@
 .shadows {
-    height: 32px;
-    width: 150px;
+    height: 50px;
+    width: 300px;
     background-color: #c8ccd1;
 }


### PR DESCRIPTION
Changing the height and width of the Shadows element to make it consistent with the Color and Transition presenters in our token documentation pages.

Bug: [T256858](https://phabricator.wikimedia.org/T256858)