### PR TITLE
Use custom kebab case function for generating token names

### DIFF
--- a/tokens/.style-dictionary/config.js
+++ b/tokens/.style-dictionary/config.js
@@ -1,12 +1,16 @@
 'use strict';
 
-const { removeWikimediaUiBaseVars, getReferencedTokens } = require( './lib' ),
-	StyleDictionary = require( 'style-dictionary' ).extend( {
+const StyleDictionary = require( 'style-dictionary' ),
+	{ removeWikimediaUiBaseVars, getReferencedTokens, kebabCase } = require( './lib' ),
+	wikitStyleDictionary = StyleDictionary.extend( {
 		include: [ 'node_modules/wikimedia-ui-base/tokens.json' ],
 		source: [ 'properties/**/*.json' ],
 		platforms: {
 			scss: {
-				transformGroup: 'scss',
+				transforms: [
+					...StyleDictionary.transformGroup.scss,
+					'name/kebabCase',
+				],
 				buildPath: 'dist/',
 				files: [ {
 					destination: '_variables.scss',
@@ -15,7 +19,10 @@ const { removeWikimediaUiBaseVars, getReferencedTokens } = require( './lib' ),
 				} ],
 			},
 			css: {
-				transformGroup: 'css',
+				transforms: [
+					...StyleDictionary.transformGroup.css,
+					'name/kebabCase',
+				],
 				buildPath: 'dist/',
 				files: [ {
 					destination: 'variables.css',
@@ -24,7 +31,10 @@ const { removeWikimediaUiBaseVars, getReferencedTokens } = require( './lib' ),
 				} ],
 			},
 			less: {
-				transformGroup: 'less',
+				transforms: [
+					...StyleDictionary.transformGroup.less,
+					'name/kebabCase',
+				],
 				buildPath: 'dist/',
 				files: [ {
 					destination: '_variables.less',
@@ -34,7 +44,8 @@ const { removeWikimediaUiBaseVars, getReferencedTokens } = require( './lib' ),
 			},
 			json: {
 				transforms: [
-					'name/cti/kebab',
+					...StyleDictionary.transformGroup.web,
+					'name/kebabCase',
 					'attr/tokenList',
 				],
 				buildPath: 'dist/',
@@ -47,10 +58,16 @@ const { removeWikimediaUiBaseVars, getReferencedTokens } = require( './lib' ),
 		},
 	} );
 
-StyleDictionary.registerTransform( {
+wikitStyleDictionary.registerTransform( {
 	name: 'attr/tokenList',
 	type: 'attribute',
 	transformer: getReferencedTokens,
 } );
 
-StyleDictionary.buildAllPlatforms();
+wikitStyleDictionary.registerTransform( {
+	name: 'name/kebabCase',
+	type: 'name',
+	transformer: kebabCase,
+} );
+
+wikitStyleDictionary.buildAllPlatforms();

--- a/tokens/.style-dictionary/lib.js
+++ b/tokens/.style-dictionary/lib.js
@@ -16,7 +16,12 @@ function getReferencedTokens( prop ) {
 	};
 }
 
+function kebabCase( { path } ) {
+	return path.join( '-' );
+}
+
 module.exports = {
 	removeWikimediaUiBaseVars,
 	getReferencedTokens,
+	kebabCase,
 };

--- a/tokens/tests/kebabCase.spec.js
+++ b/tokens/tests/kebabCase.spec.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { kebabCase } = require( '../.style-dictionary/lib' );
+
+describe( 'kebabCase', () => {
+
+	it( 'builds a token name from a path', () => {
+		expect( kebabCase( {
+			path: [ 'font', 'weight', 'style', 'h1' ],
+		} ) ).toBe( 'font-weight-style-h1' );
+	} );
+
+} );


### PR DESCRIPTION
This overrides style-dictionary's own kebab case function to prevent it
from hyphenating parts of the path that contain numbers. For example,
style-dictionary produces the name `font-weight-style-h-1` from path
`[ 'font', 'weight', 'style', 'h1' ]`, but we want it to be
`font-weight-style-h1`.

I added some extra context to what's happening inside style-dictionary in [a comment on the task](https://phabricator.wikimedia.org/T257805#6303508).