### PR TITLE
Update README for running storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,3 @@ docker-compose run --rm node lerna run test
 ```sh
 docker-compose up storybook
 ```
-
-Follow the url "On your Network" that the above command outputs.


### PR DESCRIPTION
With the introduction of a fixed Stprybook port (https://github.com/wmde/wikit/pull/71), the README does not need to say what to click to open storybook, since both localhost and the network url should work. 