### PR TITLE
docs: nowrap only for token names, not the whole column

### DIFF
--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -17,11 +17,17 @@ export function TokenTable( { tokens } ) {
 				{
 					tokens.map( ( token ) => (
 						<tr key={ token.name } id={ token.name }>
-							<td className="token-name">
+							<td>
 								<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
-							&nbsp;<strong>{ token.name }</strong>
+							&nbsp;<strong className="token-name">{ token.name }</strong>
 								<div className="referenced-tokens" title="value influenced by">
-									{ token.referencedTokens || '—' }
+									{token.referencedTokens.length > 0 ?
+										token.referencedTokens.map( ( token, i ) => [
+											i > 0 ? ', ' : '',
+											<span key={i} className="token-name">{token}</span>,
+										] ) :
+										'-'
+									}
 								</div>
 							</td>
 							<td>

--- a/docs/src/lib/flattenTokenTree.js
+++ b/docs/src/lib/flattenTokenTree.js
@@ -17,7 +17,7 @@ export function flattenTokenTree( nestedTokens ) {
 		return tokens.concat( {
 			path: node.path,
 			name: node.name,
-			referencedTokens: node.attributes.tokens.join( ', ' ),
+			referencedTokens: node.attributes.tokens,
 			value: node.value,
 		} );
 	}, [] );


### PR DESCRIPTION
A little birdie told me that the [token page for state transitions](https://wmde.github.io/wikit/?path=/docs/design-tokens-transitions-state-transitions--page#transition-interaction-button-focus-property) looked silly after my attempted improvement for avoiding word wraps on token names. I had optimistically slapped `white-space: nowrap;` on the whole table column which looks weird as soon as there are multiple token names.

This change now does what I had intended to do and avoids wrapping for individual token names.