### PR TITLE
Components storybook

### DIFF
--- a/docs/src/dummy.stories.js
+++ b/docs/src/dummy.stories.js
@@ -1,4 +1,4 @@
-import HelloWorld from '@wmde/wikit-vue-components/src/components/HelloWorld';
+import { HelloWorld } from '@wmde/wikit-vue-components';
 
 export default {
 	title: 'Components/Dummy',

--- a/docs/src/dummy.stories.js
+++ b/docs/src/dummy.stories.js
@@ -1,7 +1,15 @@
+import HelloWorld from '@wmde/wikit-vue-components/src/components/HelloWorld';
+
 export default {
-	title: 'Components',
+	title: 'Components/Dummy',
 };
 
-export function dummy() {
-	return '<p>Component stories will be shown here</p>';
+export function withText() {
+	return {
+		components: { HelloWorld },
+		template: `
+			<p>
+				<HelloWorld msg="hello world"/>
+			</p>`,
+	};
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "lerna run test",
     "storybook": "lerna run storybook --stream",
     "build:storybook": "lerna run build --scope @wmde/wikit-docs",
-    "chromatic": "lerna run chromatic --scope @wmde/wikit-docs"
+    "chromatic": "lerna run build --scope @wmde/wikit-vue-components && lerna run chromatic --scope @wmde/wikit-docs"
   },
   "devDependencies": {
     "lerna": "^3.22.1"

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -6,7 +6,7 @@
     "name": "The Wikidata team"
   },
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "dev": "vue-cli-service build --target lib --name wikit-vue-components src/main.ts --inline-vue --watch --mode development",
     "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -12,7 +12,7 @@
     "lint": "vue-cli-service lint",
     "test": "npm run lint && npm run test:unit"
   },
-  "main": "dist/index.js",
+  "main": "dist/wikit-vue-components.common.js",
   "files": [
     "src/",
     "dist/"

--- a/vue-components/src/components/HelloWorld.vue
+++ b/vue-components/src/components/HelloWorld.vue
@@ -1,34 +1,6 @@
 <template>
   <div class="hello">
-    <h1>{{ msg }}</h1>
-    <p>
-      For a guide and recipes on how to configure / customize this project,<br>
-      check out the
-      <a href="https://cli.vuejs.org" target="_blank" rel="noopener">vue-cli documentation</a>.
-    </p>
-    <h3>Installed CLI Plugins</h3>
-    <ul>
-      <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-babel" target="_blank" rel="noopener">babel</a></li>
-      <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-typescript" target="_blank" rel="noopener">typescript</a></li>
-      <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-eslint" target="_blank" rel="noopener">eslint</a></li>
-      <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest" target="_blank" rel="noopener">unit-jest</a></li>
-    </ul>
-    <h3>Essential Links</h3>
-    <ul>
-      <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
-      <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
-      <li><a href="https://chat.vuejs.org" target="_blank" rel="noopener">Community Chat</a></li>
-      <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
-      <li><a href="https://news.vuejs.org" target="_blank" rel="noopener">News</a></li>
-    </ul>
-    <h3>Ecosystem</h3>
-    <ul>
-      <li><a href="https://router.vuejs.org" target="_blank" rel="noopener">vue-router</a></li>
-      <li><a href="https://vuex.vuejs.org" target="_blank" rel="noopener">vuex</a></li>
-      <li><a href="https://github.com/vuejs/vue-devtools#vue-devtools" target="_blank" rel="noopener">vue-devtools</a></li>
-      <li><a href="https://vue-loader.vuejs.org" target="_blank" rel="noopener">vue-loader</a></li>
-      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank" rel="noopener">awesome-vue</a></li>
-    </ul>
+    {{ msg }}
   </div>
 </template>
 
@@ -43,20 +15,8 @@ export default Vue.extend({
 })
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-h3 {
-  margin: 40px 0 0;
-}
-ul {
-  list-style-type: none;
-  padding: 0;
-}
-li {
-  display: inline-block;
-  margin: 0 10px;
-}
-a {
-  color: #42b983;
+.hello {
+  color: #f00;
 }
 </style>


### PR DESCRIPTION
This demonstrates that component hot reloading works without additional configuration in storybook as long as we import the components from the `src/` directory. Lerna does the right thing and links these files as expected. Looking at the dependency from the docs package to the vue-components package this is fine, because the `src/` files are part of the package contents.

It does come with a risk of creating a disconnect between the standard usage of components and how we use storybook to develop them, think `import { Component } from '@wmde/wikit-vue-components';` vs `import Component from '@wmde/wikit-vue-components/src/components/Component';`. I think that this is probably fine for now and we can revisit this if it becomes a problem.

Bug: https://phabricator.wikimedia.org/T257825