### PR TITLE
Add docs for vue being external to the lib

### DIFF
--- a/docs/src/doc/01_getting_started.stories.mdx
+++ b/docs/src/doc/01_getting_started.stories.mdx
@@ -2,12 +2,18 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Documentation|Getting started" />
 
-# Wikit
+# WiKit
 
-This documents the work on the Wikit product, our Design System.
+This documents the work on the WiKit product, our Design System.
 
 The documentation is organized into these categories:
 
 * process - documentation which covers cross-trade work on this product
 * UX - documentation which covers topics exclusive to the UX realm
 * dev - documentation which covers topics exclusive to the dev realm
+
+## Vue Components
+
+The package `vue-components` is a user interface component library that implements the WiKit design system.
+The library assumes it is going to be used in a Vue project, therefor Vue is externalized.
+


### PR DESCRIPTION
### Externalize MW-supported packages [T257827](https://phabricator.wikimedia.org/T257827)

Documenting Vue being external, rather than defining it in the code as it makes no difference - [vue-cli docs](https://cli.vuejs.org/guide/build-targets.html#library)