### PR TITLE
Install and configure Stylelint

### DIFF
--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1706,6 +1706,34 @@
 				"unified": "9.0.0",
 				"unist-builder": "2.0.3",
 				"unist-util-visit": "2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+					"dev": true
+				},
+				"unified": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
+					"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+					"dev": true,
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@mdx-js/react": {
@@ -1730,11 +1758,39 @@
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				}
+			}
+		},
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
 		},
 		"@npmcli/move-file": {
 			"version": "1.0.1",
@@ -3346,6 +3402,25 @@
 				"webpack": "^4.43.0"
 			}
 		},
+		"@stylelint/postcss-css-in-js": {
+			"version": "0.37.2",
+			"resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
+			"integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": ">=7.9.0"
+			}
+		},
+		"@stylelint/postcss-markdown": {
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.1.tgz",
+			"integrity": "sha512-iDxMBWk9nB2BPi1VFQ+Dc5+XpvODBHw2n3tYpaBZuEAFQlbtF9If0Qh5LTTwSi/XwdbJ2jt+0dis3i8omyggpw==",
+			"dev": true,
+			"requires": {
+				"remark": "^12.0.0",
+				"unist-util-find-all-after": "^3.0.1"
+			}
+		},
 		"@types/anymatch": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -3555,6 +3630,12 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
+		"@types/minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
 			"dev": true
 		},
 		"@types/node": {
@@ -5080,9 +5161,9 @@
 			}
 		},
 		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
 			"dev": true
 		},
 		"asap": {
@@ -6581,6 +6662,17 @@
 			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"dev": true
 		},
+		"camelcase-keys": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"map-obj": "^4.0.0",
+				"quick-lru": "^4.0.1"
+			}
+		},
 		"caniuse-api": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -6651,6 +6743,12 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
 			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+			"dev": true
+		},
+		"character-entities-html4": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+			"integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
 			"dev": true
 		},
 		"character-entities-legacy": {
@@ -7099,6 +7197,15 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
+		},
+		"clone-regexp": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+			"integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+			"dev": true,
+			"requires": {
+				"is-regexp": "^2.0.0"
+			}
 		},
 		"co": {
 			"version": "4.6.0",
@@ -7998,6 +8105,24 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
+		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				}
+			}
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -10055,6 +10180,15 @@
 				"strip-eof": "^1.0.0"
 			}
 		},
+		"execall": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+			"integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+			"dev": true,
+			"requires": {
+				"clone-regexp": "^2.1.0"
+			}
+		},
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -10358,6 +10492,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"fault": {
 			"version": "1.0.4",
@@ -10858,6 +11001,12 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+			"integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -11034,6 +11183,21 @@
 				"slash": "^2.0.0"
 			}
 		},
+		"globjoin": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+			"dev": true
+		},
+		"gonzales-pe": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+			"integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
 		"good-listener": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -11093,6 +11257,12 @@
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
+		},
+		"hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
@@ -11714,6 +11884,12 @@
 				"resolve-from": "^3.0.0"
 			}
 		},
+		"import-lazy": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+			"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+			"dev": true
+		},
 		"import-local": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -11979,6 +12155,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
 			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+			"dev": true
+		},
+		"is-alphanumeric": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
 			"dev": true
 		},
 		"is-alphanumerical": {
@@ -12258,6 +12440,12 @@
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
+		},
+		"is-regexp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+			"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.1.0",
@@ -13448,6 +13636,12 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"known-css-properties": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
+			"integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
+			"dev": true
+		},
 		"launch-editor": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.2.1.tgz",
@@ -13729,6 +13923,12 @@
 			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
 			"dev": true
 		},
+		"longest-streak": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+			"dev": true
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13802,6 +14002,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+			"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+			"dev": true
+		},
 		"map-or-similar": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -13823,6 +14029,15 @@
 			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
 			"dev": true
 		},
+		"markdown-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+			"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+			"dev": true,
+			"requires": {
+				"repeat-string": "^1.0.0"
+			}
+		},
 		"markdown-to-jsx": {
 			"version": "6.11.4",
 			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
@@ -13837,6 +14052,12 @@
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
 			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+			"dev": true
+		},
+		"mathml-tag-names": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
 			"dev": true
 		},
 		"md5.js": {
@@ -13857,6 +14078,15 @@
 			"dev": true,
 			"requires": {
 				"unist-util-remove": "^2.0.0"
+			}
+		},
+		"mdast-util-compact": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
+			"integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit": "^2.0.0"
 			}
 		},
 		"mdast-util-definitions": {
@@ -13935,6 +14165,112 @@
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
 			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
 			"dev": true
+		},
+		"meow": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+			"integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+			"dev": true,
+			"requires": {
+				"@types/minimist": "^1.2.0",
+				"arrify": "^2.0.1",
+				"camelcase": "^6.0.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "^4.0.2",
+				"normalize-package-data": "^2.5.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.13.1",
+				"yargs-parser": "^18.1.3"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.8.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+							"dev": true
+						}
+					}
+				},
+				"type-fest": {
+					"version": "0.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
+					}
+				}
+			}
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
@@ -14058,6 +14394,12 @@
 				"dom-walk": "^0.1.0"
 			}
 		},
+		"min-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"dev": true
+		},
 		"mini-css-extract-plugin": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
@@ -14121,6 +14463,25 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
+		},
+		"minimist-options": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
+			},
+			"dependencies": {
+				"arrify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+					"dev": true
+				}
+			}
 		},
 		"minipass": {
 			"version": "3.1.3",
@@ -14495,6 +14856,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+			"dev": true
+		},
+		"normalize-selector": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
 		},
 		"normalize-url": {
@@ -15430,6 +15797,24 @@
 				"postcss": "^7.0.26"
 			}
 		},
+		"postcss-html": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.10.0"
+			}
+		},
+		"postcss-less": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.14"
+			}
+		},
 		"postcss-load-config": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
@@ -15473,6 +15858,12 @@
 			"requires": {
 				"postcss": "^7.0.17"
 			}
+		},
+		"postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+			"dev": true
 		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
@@ -15867,6 +16258,52 @@
 				}
 			}
 		},
+		"postcss-reporter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"lodash": "^4.17.11",
+				"log-symbols": "^2.2.0",
+				"postcss": "^7.0.7"
+			}
+		},
+		"postcss-resolve-nested-selector": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+			"dev": true
+		},
+		"postcss-safe-parser": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+			"integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.26"
+			}
+		},
+		"postcss-sass": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
+			"integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
+			"dev": true,
+			"requires": {
+				"gonzales-pe": "^4.3.0",
+				"postcss": "^7.0.21"
+			}
+		},
+		"postcss-scss": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+			"integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.6"
+			}
+		},
 		"postcss-selector-parser": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
@@ -15897,6 +16334,12 @@
 					"dev": true
 				}
 			}
+		},
+		"postcss-syntax": {
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -16389,6 +16832,12 @@
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
 		},
+		"quick-lru": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"dev": true
+		},
 		"ramda": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
@@ -16520,6 +16969,12 @@
 					"requires": {
 						"@babel/highlight": "^7.8.3"
 					}
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+					"dev": true
 				},
 				"browserslist": {
 					"version": "4.10.0",
@@ -17086,6 +17541,27 @@
 				"minimatch": "3.0.4"
 			}
 		},
+		"redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"requires": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"dependencies": {
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				}
+			}
+		},
 		"refractor": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
@@ -17227,6 +17703,17 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
+		"remark": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
+			"integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
+			"dev": true,
+			"requires": {
+				"remark-parse": "^8.0.0",
+				"remark-stringify": "^8.0.0",
+				"unified": "^9.0.0"
+			}
+		},
 		"remark-external-links": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-6.1.0.tgz",
@@ -17277,6 +17764,34 @@
 				"is-alphabetical": "1.0.4",
 				"remark-parse": "8.0.3",
 				"unified": "9.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+					"dev": true
+				},
+				"unified": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
+					"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+					"dev": true,
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				}
 			}
 		},
 		"remark-parse": {
@@ -17321,6 +17836,28 @@
 			"dev": true,
 			"requires": {
 				"mdast-squeeze-paragraphs": "^4.0.0"
+			}
+		},
+		"remark-stringify": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+			"integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
+			"dev": true,
+			"requires": {
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^2.0.0",
+				"mdast-util-compact": "^2.0.0",
+				"parse-entities": "^2.0.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^3.0.0",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -17523,6 +18060,12 @@
 			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
 		"rfdc": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
@@ -17579,6 +18122,12 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
+		},
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
 			"dev": true
 		},
 		"run-queue": {
@@ -18346,6 +18895,12 @@
 				}
 			}
 		},
+		"specificity": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+			"dev": true
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -18596,6 +19151,19 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"stringify-entities": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
+			"integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
+			"dev": true,
+			"requires": {
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.2",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -18666,6 +19234,12 @@
 				}
 			}
 		},
+		"style-search": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+			"dev": true
+		},
 		"style-to-object": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
@@ -18697,6 +19271,327 @@
 						"uniq": "^1.0.1"
 					}
 				}
+			}
+		},
+		"stylelint": {
+			"version": "13.6.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.1.tgz",
+			"integrity": "sha512-XyvKyNE7eyrqkuZ85Citd/Uv3ljGiuYHC6UiztTR6sWS9rza8j3UeQv/eGcQS9NZz/imiC4GKdk1EVL3wst5vw==",
+			"dev": true,
+			"requires": {
+				"@stylelint/postcss-css-in-js": "^0.37.1",
+				"@stylelint/postcss-markdown": "^0.36.1",
+				"autoprefixer": "^9.8.0",
+				"balanced-match": "^1.0.0",
+				"chalk": "^4.1.0",
+				"cosmiconfig": "^6.0.0",
+				"debug": "^4.1.1",
+				"execall": "^2.0.0",
+				"file-entry-cache": "^5.0.1",
+				"get-stdin": "^8.0.0",
+				"global-modules": "^2.0.0",
+				"globby": "^11.0.1",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.1.0",
+				"ignore": "^5.1.8",
+				"import-lazy": "^4.0.0",
+				"imurmurhash": "^0.1.4",
+				"known-css-properties": "^0.19.0",
+				"leven": "^3.1.0",
+				"lodash": "^4.17.15",
+				"log-symbols": "^4.0.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^7.0.1",
+				"micromatch": "^4.0.2",
+				"normalize-selector": "^0.2.0",
+				"postcss": "^7.0.32",
+				"postcss-html": "^0.36.0",
+				"postcss-less": "^3.1.4",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-reporter": "^6.0.1",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^4.0.2",
+				"postcss-sass": "^0.4.4",
+				"postcss-scss": "^2.1.1",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-syntax": "^0.36.2",
+				"postcss-value-parser": "^4.1.0",
+				"resolve-from": "^5.0.0",
+				"slash": "^3.0.0",
+				"specificity": "^0.4.1",
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"style-search": "^0.1.0",
+				"sugarss": "^2.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^5.4.6",
+				"v8-compile-cache": "^2.1.1",
+				"write-file-atomic": "^3.0.3"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.7.2"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"html-tags": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+					"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+					"dev": true
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"import-fresh": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					},
+					"dependencies": {
+						"resolve-from": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+							"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+							"dev": true
+						}
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+					"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
+					}
+				}
+			}
+		},
+		"stylelint-config-recommended": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+			"dev": true
+		},
+		"stylelint-config-standard": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-20.0.0.tgz",
+			"integrity": "sha512-IB2iFdzOTA/zS4jSVav6z+wGtin08qfj+YyExHB3LF9lnouQht//YyB0KZq9gGz5HNPkddHOzcY8HsUey6ZUlA==",
+			"dev": true,
+			"requires": {
+				"stylelint-config-recommended": "^3.0.0"
+			}
+		},
+		"stylelint-processor-html": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-processor-html/-/stylelint-processor-html-1.0.0.tgz",
+			"integrity": "sha1-aJK2soVaRfApHNhFGR1pCBMKKRg=",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.9.1"
+			}
+		},
+		"stylelint-use-logical": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-1.1.0.tgz",
+			"integrity": "sha512-WwYAEoUNXxu4A9tZ+mPnvFSf3wKG9mY9+ZqnNjVHikfOQA4MTO6XeSC8BGCsY7LOG0GnDfmxMrRUJXFZRtaCmg==",
+			"dev": true
+		},
+		"sugarss": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.2"
 			}
 		},
 		"supports-color": {
@@ -19175,6 +20070,12 @@
 			"integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
 			"dev": true
 		},
+		"trim-newlines": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+			"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+			"dev": true
+		},
 		"trim-trailing-lines": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
@@ -19536,9 +20437,9 @@
 			"dev": true
 		},
 		"unified": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-			"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
+			"integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
 			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
@@ -19610,6 +20511,15 @@
 			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
 			"integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
 			"dev": true
+		},
+		"unist-util-find-all-after": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.1.tgz",
+			"integrity": "sha512-0GICgc++sRJesLwEYDjFVJPJttBpVQaTNgc6Jw0Jhzvfs+jtKePEMu+uD+PqkRUrAvGQqwhpDwLGWo1PK8PDEw==",
+			"dev": true,
+			"requires": {
+				"unist-util-is": "^4.0.0"
+			}
 		},
 		"unist-util-generated": {
 			"version": "1.1.5",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -10,8 +10,10 @@
     "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
     "test:unit": "vue-cli-service test:unit",
     "test:lint": "vue-cli-service lint --no-fix",
+    "test:lintcss": "stylelint '**/*.vue'",
     "test": "npm-run-all test:*",
     "fix": "vue-cli-service lint",
+    "fix:css": "stylelint '**/*.vue' --fix",
     "build:storybook": "build-storybook",
     "storybook": "start-storybook"
   },
@@ -52,6 +54,9 @@
     "postcss-dir-pseudo-class": "^5.0.0",
     "postcss-logical": "^4.0.2",
     "postcss-prefixwrap": "^1.16.0",
+    "stylelint": "^13.6.1",
+    "stylelint-config-standard": "^20.0.0",
+    "stylelint-use-logical": "^1.1.0",
     "typescript": "~3.9.3",
     "vue-template-compiler": "^2.6.11"
   },

--- a/vue-components/src/components/HelloWorld.vue
+++ b/vue-components/src/components/HelloWorld.vue
@@ -32,7 +32,7 @@ export default Vue.extend( {
 
 <style scoped>
 .hello {
-	color: #222222;
+	color: #222;
 	inset: logical 0 5px 10px;
 	padding-inline: 20px 40px;
 	resize: block;

--- a/vue-components/stylelint.config.js
+++ b/vue-components/stylelint.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	extends: [
+		'stylelint-config-standard',
+	],
+	plugins: [
+		'stylelint-use-logical',
+	],
+	rules: {
+		'indentation': 'tab',
+		'csstools/use-logical': 'always',
+	},
+};


### PR DESCRIPTION
This PR installs Stylelint to help us lint our style code (css/scss).
The config follows the docs and uses `stylelint-config-standard` with the only change to use indentation of tabs instead 2 spaces (default).
The plugin `stylelint-use-logical` is used to lint for css logical properties, which we introduced in the parent branch of this PR.