### PR TITLE
Style scoping and style reset

### DIFF
--- a/vue-components/build/postcssWikitScope.js
+++ b/vue-components/build/postcssWikitScope.js
@@ -1,0 +1,35 @@
+const postcss = require( 'postcss' );
+const selectorParser = require( 'postcss-selector-parser' );
+
+// copied & modified from https://github.com/pazams/postcss-scopify/blob/master/index.js#L86
+function isRuleScopable( rule ) {
+	if ( rule.parent.type !== 'root' ) {
+		return rule.parent.type === 'atrule' && [ 'media', 'supports', 'document' ].includes( rule.parent.name );
+	} else {
+		return true;
+	}
+}
+
+const addWikitClassToFirstSelectorNode = selectorParser( ( selectors ) => {
+	const selector = selectors.first; // there is always only one selector passed at a time from where it's called
+	const wikitClassNode = selectorParser.className( { value: 'wikit' } );
+	if ( [ 'pseudo', 'attribute' ].includes( selector.first.type ) ) {
+		selector.insertBefore( selector.first, wikitClassNode );
+	} else {
+		selector.insertAfter( selector.first, wikitClassNode );
+	}
+} );
+
+function applyWikitScope( selector ) {
+	return `.wikit ${selector}, ${addWikitClassToFirstSelectorNode.processSync( selector )}`;
+}
+
+module.exports = postcss.plugin( 'wikit-scope', () => ( ( root ) => {
+	root.walkRules( ( rule ) => {
+		if ( !isRuleScopable( rule ) ) {
+			return;
+		}
+
+		rule.selectors = rule.selectors.map( applyWikitScope );
+	} );
+} ) );

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -18019,6 +18019,11 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
+		"ress": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ress/-/ress-3.0.0.tgz",
+			"integrity": "sha512-MTPto7t44AawqmSbEmvMKoSMWPnxjaTuHf94s7RjWxuSGFN0o8/b+6yOwkaC50+Vihjsu6ODUEQR397gTMn57w=="
+		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -16230,12 +16230,6 @@
 				}
 			}
 		},
-		"postcss-prefixwrap": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.16.0.tgz",
-			"integrity": "sha512-HQIk1ZYH/8ziVkE6O99aV1ykpRv85onurhpOv5YnbART/s3rSRAAzbwj33tlEQ8wouMJUx2gomKRhmiz5THbmg==",
-			"dev": true
-		},
 		"postcss-reduce-initial": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -56,7 +56,6 @@
     "npm-run-all": "^4.1.5",
     "postcss-dir-pseudo-class": "^5.0.0",
     "postcss-logical": "^4.0.2",
-    "postcss-prefixwrap": "^1.16.0",
     "sass": "^1.26.10",
     "sass-loader": "^9.0.2",
     "stylelint": "^13.6.1",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",
     "core-js": "^3.6.5",
+    "ress": "^3.0.0",
     "vue": "^2.6.11"
   },
   "devDependencies": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -54,6 +54,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^6.2.2",
     "npm-run-all": "^4.1.5",
+    "postcss": "^7.0.32",
+    "postcss-selector-parser": "^6.0.2",
     "postcss-dir-pseudo-class": "^5.0.0",
     "postcss-logical": "^4.0.2",
     "sass": "^1.26.10",

--- a/vue-components/postcss.config.js
+++ b/vue-components/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	plugins: [
 		require( 'autoprefixer' ),
-		require( 'postcss-prefixwrap' )( '.wikit' ),
 		require( 'postcss-logical' )( { preserve: true } ),
 		require( 'postcss-dir-pseudo-class' ),
 	],

--- a/vue-components/postcss.config.js
+++ b/vue-components/postcss.config.js
@@ -1,6 +1,9 @@
+const wikitScope = require( './build/postcssWikitScope' );
+
 module.exports = {
 	plugins: [
 		require( 'autoprefixer' ),
+		wikitScope,
 		require( 'postcss-logical' )( { preserve: true } ),
 		require( 'postcss-dir-pseudo-class' ),
 	],

--- a/vue-components/tests/unit/build/postcssWikitScope.spec.ts
+++ b/vue-components/tests/unit/build/postcssWikitScope.spec.ts
@@ -1,0 +1,40 @@
+const postcss = require( 'postcss' );
+const wikitScope = require( '../../../build/postcssWikitScope' );
+
+async function processWithPlugin( input: string ): Promise<{ css: string }> {
+	return postcss( [ wikitScope ] ).process( input, { from: undefined } );
+}
+
+describe( 'postcssWikitScope', () => {
+
+	it.each( [
+		[
+			'.foo {}',
+			'.wikit .foo, .foo.wikit {}',
+		],
+		[
+			'::before {}',
+			'.wikit ::before, .wikit::before {}',
+		],
+		[
+			'[type="button"] {}',
+			'.wikit [type="button"], .wikit[type="button"] {}',
+		],
+		[
+			'div [type=button] {}',
+			'.wikit div [type=button], div.wikit [type=button] {}',
+		],
+		[
+			'.foo a:hover {}',
+			'.wikit .foo a:hover, .foo.wikit a:hover {}',
+		],
+		[
+			'a:hover {}',
+			'.wikit a:hover, a.wikit:hover {}',
+		],
+	] )( 'applies .wikit scoping', async ( input, expected ) => {
+		const { css } = await processWithPlugin( input );
+		expect( css ).toEqual( expected );
+	} );
+
+} );

--- a/vue-components/vue.config.js
+++ b/vue-components/vue.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	css: {
 		loaderOptions: {
 			sass: {
+				additionalData: '@at-root { @import "~ress"; }',
 			},
 		},
 	},


### PR DESCRIPTION
* removes the `postcss-prefixwrap` scoping which didn't work as intended due to the lack of a shared root node
* adds the custom postcss plugin which limits the selector scope to `.wikit` elements and elements within `.wikit` elements, effectively applying `.wikit ${selector}, ${selector}.wikit` everywhere, with adjustments for pseudo and attribute selectors
* adds ress via sass-loader's `additionalData`