### PR TITLE
docs: storybook: mdx only

### DIFF
--- a/docs/.storybook/main.js
+++ b/docs/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-	stories: [ '../src/**/*.stories.@(js|mdx)' ],
+	stories: [ '../src/**/*.stories.mdx' ],
 	addons: [
 		'@storybook/addon-a11y',
 		'@storybook/addon-docs',

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "test:lint": "eslint . --ext .js --ext .jsx",
     "fix": "npm run test:lint -- --fix",
     "build": "build-storybook -o dist",
-    "chromatic": "chromatic build --project-token=3evi132fpys --storybook-build-dir dist"
+    "chromatic": "chromatic build --project-token=3evi132fpys --storybook-build-dir dist --exit-once-uploaded"
   },
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "test:lint": "eslint . --ext .js --ext .jsx",
     "fix": "npm run test:lint -- --fix",
     "build": "build-storybook -o dist",
-    "chromatic": "npx chromatic build --project-token=3evi132fpys --storybook-build-dir dist"
+    "chromatic": "chromatic build --project-token=3evi132fpys --storybook-build-dir dist"
   },
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",
@@ -41,7 +41,7 @@
     "@storybook/addon-knobs": "^6.0.0-rc.25",
     "@storybook/html": "^6.0.0-rc.25",
     "babel-loader": "^8.1.0",
-    "chromatic": "^5.0.0",
+    "chromatic": "^5.1.0",
     "eslint": "^7.3.1",
     "eslint-config-wikimedia": "^0.16.2",
     "eslint-plugin-react": "^7.20.3",

--- a/docs/src/dummy.stories.js
+++ b/docs/src/dummy.stories.js
@@ -1,7 +1,0 @@
-export default {
-	title: 'Components',
-};
-
-export function dummy() {
-	return '<p>Component stories will be shown here</p>';
-}


### PR DESCRIPTION
It's surprising to me that `--exit-once-uploaded` in 091858b does not work out, given [its description](https://www.chromatic.com/docs/cli#chromatic-options) but that does seem to be subject to interpretation.

Feel free to edit.

Bug: https://phabricator.wikimedia.org/T259694