### PR TITLE
Make browser tests work in composed and single storybooks

### DIFF
--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -4,6 +4,8 @@ const build = `Nightwatch build-${process.env.DATE}`;
 module.exports = {
 	src_folders: [ 'tests/e2e/specs' ],
 	page_objects_path: 'tests/e2e/page-objects',
+	custom_assertions_path: 'tests/e2e/custom-assertions',
+	custom_commands_path: 'tests/e2e/custom-commands',
 
 	test_workers: {
 		enabled: true,

--- a/vue-components/tests/e2e/custom-commands/openComponentStory.js
+++ b/vue-components/tests/e2e/custom-commands/openComponentStory.js
@@ -2,10 +2,14 @@ module.exports.command = function openComponentStory( component ) {
 	return this.waitForElementVisible( '#root' )
 		.click( `a[href="#${component}"]` )
 		.element(
-			'css selector',
-			'[id="storybook-ref-vue"]',
+			'id',
+			'storybook-ref-vue',
 			( { value } ) => {
-				this.frame( value );
+				if ( value && !value.error ) {
+					this.frame( value ); // storybook composition
+				} else {
+					this.frame( 'storybook-preview-iframe' ); // vue-components storybook, no composition
+				}
 			},
 		);
 };

--- a/vue-components/tests/e2e/custom-commands/openComponentStory.js
+++ b/vue-components/tests/e2e/custom-commands/openComponentStory.js
@@ -1,0 +1,11 @@
+module.exports.command = function openComponentStory( component ) {
+	return this.waitForElementVisible( '#root' )
+		.click( `a[href="#${component}"]` )
+		.element(
+			'css selector',
+			'[id="storybook-ref-vue"]',
+			( { value } ) => {
+				this.frame( value );
+			},
+		);
+};

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -2,19 +2,9 @@ module.exports = {
 	'default e2e tests': ( client ) => {
 		client
 			.init()
-			.waitForElementVisible( '#root' ) // Storybook's root node
-			.click( 'a[href="#button"]' ); // load the vue components frame
-
-		client.element(
-			'css selector',
-			'[id="storybook-ref-vue"]',
-			( result ) => {
-				const frameWebElementId = result.value;
-				client.frame( frameWebElementId );
-				client.waitForElementVisible( '.wikit-Button' );
-				client.assert.elementPresent( '.wikit-Button' );
-				client.end();
-			},
-		);
+			.openComponentStory( 'button' )
+			.waitForElementVisible( '.wikit-Button' )
+			.assert.elementPresent( '.wikit-Button' )
+			.end();
 	},
 };


### PR DESCRIPTION
Adds a custom nightwatch command that "hides" the code that selects the iframe.