### PR TITLE
Dockerize browsertests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ docker-compose run --rm node lerna run test
 
 #### Local
 
-To run browser tests locally make sure `storybook-vue` is up and running. Navigate to `vue-components` subdirectory and run 
+To run browser tests locally make sure `storybook-vue` is up and running. Navigate to `vue-components` subdirectory and run it with your storybook URL specified, e.g.
 ```sh
-npm run e2e
+STORYBOOK_URL=localhost:6005 npm run e2e
 ```
 
 #### Cross-browser testing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ docker-compose run --rm node lerna run test
 
 #### Local
 
-To run browser tests locally make sure `storybook-vue` is up and running. Navigate to `vue-components` subdirectory and run it with your storybook URL specified, e.g.
+To run browser tests locally make sure `storybook-vue` is up and running.
+
+##### In Docker
+
+```sh
+docker-compose -f docker-compose.yml -f docker-compose.browsertests.yml up browsertests
+```
+
+##### On the host machine
+
+Navigate to `vue-components` subdirectory and run it with your storybook URL specified, e.g.
 ```sh
 STORYBOOK_URL=localhost:6005 npm run e2e
 ```

--- a/docker-compose.browsertests.yml
+++ b/docker-compose.browsertests.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+    browsertests:
+        extends:
+            service: node
+        command: 'lerna run e2e --scope @wmde/wikit-vue-components -- -- --config nightwatch.config.js --env docker'
+        environment:
+            - VUECOMPONENTS_STORYBOOK_PORT
+        depends_on:
+            - selenium
+            - storybook-vue
+    selenium:
+        image: selenium/standalone-chrome
+        shm_size: '2gb'
+        depends_on:
+            - storybook-vue

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -16,7 +16,7 @@ module.exports = {
 		// full default config at
 		// https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
 		default: {
-			launch_url: 'localhost:6006',
+			launch_url: process.env.STORYBOOK_URL,
 		},
 		sauceLabs: {
 			launch_url: `https://${process.env.BRANCH_NAME}--5efdb3b5f65950002286285d.chromatic.com`,

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -18,6 +18,17 @@ module.exports = {
 		default: {
 			launch_url: process.env.STORYBOOK_URL,
 		},
+		docker: {
+			launch_url: `http://storybook-vue:${process.env.VUECOMPONENTS_STORYBOOK_PORT}`,
+			selenium_host: 'selenium',
+			desiredCapabilities: {
+				browserName: 'chrome',
+				chromeOptions: {
+					args: [ 'headless', 'no-sandbox', 'disable-gpu' ],
+					w3c: false,
+				},
+			},
+		},
 		sauceLabs: {
 			launch_url: `https://${process.env.BRANCH_NAME}--5efdb3b5f65950002286285d.chromatic.com`,
 			selenium_host: 'ondemand.saucelabs.com',

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -9,7 +9,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
     "test:unit": "vue-cli-service test:unit",
-    "e2e": "vue-cli-service test:e2e --url https://localhost:6006/",
+    "e2e": "vue-cli-service test:e2e",
     "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge",
     "build:extract-stories": "npx sb@6.0.0-rc.24 extract storybook-static storybook-static/stories.json",
     "build:storybook": "build-storybook",


### PR DESCRIPTION
I think this should work well enough for now!

Despite the `depends_on` in the `docker-compose.browsertests.yml` I observed occasional hiccups during the first run of the browser tests when the `browsertests` service is faster its dependencies (`selenium` and `storybook-vue`). This problem seemed to go away once the containers have been started once, i.e. it won't fail again once it successfully ran. TL;DR run it again if it fails for weird reasons once, then it should be fine.