### PR TITLE
browser tests: increase timeout from 5s to 20s

### DIFF
--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -6,6 +6,7 @@ module.exports = {
 	page_objects_path: 'tests/e2e/page-objects',
 	custom_assertions_path: 'tests/e2e/custom-assertions',
 	custom_commands_path: 'tests/e2e/custom-commands',
+	globals_path: 'tests/e2e/globals.js',
 
 	test_workers: {
 		enabled: true,

--- a/vue-components/tests/e2e/globals.js
+++ b/vue-components/tests/e2e/globals.js
@@ -18,7 +18,7 @@ module.exports = {
 
 	// default timeout value in milliseconds for waitFor commands and implicit waitFor value for
 	// expect assertions
-	waitForConditionTimeout: 5000,
+	waitForConditionTimeout: 20000,
 
 	'default': {
 		/*


### PR DESCRIPTION
I've seen the tests time out twice already on the `this.waitForElementVisible( '#root' )` in the `openComponentStory` since we enabled them yesterday.