### PR TITLE
Move Chromatic to run on the vue-components package

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -506,15 +506,6 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
-		"@babel/plugin-syntax-bigint": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			}
-		},
 		"@babel/plugin-syntax-class-properties": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
@@ -558,15 +549,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
-			}
-		},
-		"@babel/plugin-syntax-import-meta": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
@@ -1228,35 +1210,6 @@
 			"integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
 			"dev": true
 		},
-		"@bcoe/v8-coverage": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-			"dev": true
-		},
-		"@chromaui/localtunnel": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@chromaui/localtunnel/-/localtunnel-2.0.1.tgz",
-			"integrity": "sha512-QvO1J9drc7K2SeBrHuO5/8nQ1QTks/OOG+vwva4lM7T28pPgf556snMpPE/3KE6uD2UJky8I4A5dNRNbqAXiDw==",
-			"dev": true,
-			"requires": {
-				"axios": "0.19.0",
-				"debug": "^3.0.1",
-				"openurl": "^1.1.1",
-				"yargs": "^13.3.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1459,475 +1412,6 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
 			"dev": true
 		},
-		"@jest/console": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
-			"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"jest-message-util": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@jest/core": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
-			"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/reporters": "^25.5.1",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^25.5.0",
-				"jest-config": "^25.5.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-message-util": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-resolve-dependencies": "^25.5.4",
-				"jest-runner": "^25.5.4",
-				"jest-runtime": "^25.5.4",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
-				"jest-watcher": "^25.5.0",
-				"micromatch": "^4.0.2",
-				"p-each-series": "^2.1.0",
-				"realpath-native": "^2.0.0",
-				"rimraf": "^3.0.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@jest/environment": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
-			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
-			"dev": true,
-			"requires": {
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0"
-			}
-		},
-		"@jest/fake-timers": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
-			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"lolex": "^5.0.0"
-			}
-		},
-		"@jest/globals": {
-			"version": "25.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
-			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
-			"dev": true,
-			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"expect": "^25.5.0"
-			}
-		},
-		"@jest/reporters": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
-			"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
-			"dev": true,
-			"requires": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.2.4",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^25.5.1",
-				"jest-resolve": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
-				"node-notifier": "^6.0.0",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^3.1.0",
-				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^4.1.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@jest/source-map": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
-			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
-			"dev": true,
-			"requires": {
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.4",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"@jest/test-result": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
-			"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
-			}
-		},
-		"@jest/test-sequencer": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
-			"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
-			"dev": true,
-			"requires": {
-				"@jest/test-result": "^25.5.0",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-runner": "^25.5.4",
-				"jest-runtime": "^25.5.4"
-			}
-		},
-		"@jest/transform": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
-			"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/types": "^25.5.0",
-				"babel-plugin-istanbul": "^6.0.0",
-				"chalk": "^3.0.0",
-				"convert-source-map": "^1.4.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-regex-util": "^25.2.6",
-				"jest-util": "^25.5.0",
-				"micromatch": "^4.0.2",
-				"pirates": "^4.0.1",
-				"realpath-native": "^2.0.0",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.1",
-				"write-file-atomic": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@jest/types": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-			"dev": true,
-			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"@mdx-js/loader": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.16.tgz",
@@ -2060,24 +1544,6 @@
 				"invariant": "^2.2.3",
 				"prop-types": "^15.6.1",
 				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
-		"@samverschueren/stream-to-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-			"dev": true,
-			"requires": {
-				"any-observable": "^0.3.0"
-			}
-		},
-		"@sinonjs/commons": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
-			"dev": true,
-			"requires": {
-				"type-detect": "4.0.8"
 			}
 		},
 		"@storybook/addon-a11y": {
@@ -3049,47 +2515,6 @@
 			"integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
 			"dev": true
 		},
-		"@types/babel__core": {
-			"version": "7.1.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
-			"dev": true,
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
-			"dev": true,
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__traverse": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-			"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.3.0"
-			}
-		},
 		"@types/braces": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",
@@ -3169,16 +2594,6 @@
 				"@types/istanbul-lib-coverage": "*"
 			}
 		},
-		"@types/istanbul-reports": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-			"dev": true,
-			"requires": {
-				"@types/istanbul-lib-coverage": "*",
-				"@types/istanbul-lib-report": "*"
-			}
-		},
 		"@types/json-schema": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -3218,12 +2633,6 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
-		"@types/minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
-			"dev": true
-		},
 		"@types/node": {
 			"version": "14.0.27",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
@@ -3253,12 +2662,6 @@
 				}
 			}
 		},
-		"@types/normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-			"dev": true
-		},
 		"@types/npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.2.tgz",
@@ -3281,12 +2684,6 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
 			"integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
-			"dev": true
-		},
-		"@types/prettier": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
 			"dev": true
 		},
 		"@types/prop-types": {
@@ -3353,12 +2750,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
 			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-			"dev": true
-		},
-		"@types/stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
 		},
 		"@types/tapable": {
@@ -3639,12 +3030,6 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
-		"abab": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-			"integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
-			"dev": true
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3661,34 +3046,10 @@
 			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
 			"dev": true
 		},
-		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-			"dev": true,
-			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
-				}
-			}
-		},
 		"acorn-jsx": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-			"dev": true
-		},
-		"acorn-walk": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"address": {
@@ -3826,12 +3187,6 @@
 				"entities": "^1.1.2"
 			}
 		},
-		"any-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-			"dev": true
-		},
 		"anymatch": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -3889,12 +3244,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
-		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
 		"array-flatten": {
@@ -3974,15 +3323,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
 		"asn1.js": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -4030,12 +3370,6 @@
 				}
 			}
 		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -4060,15 +3394,6 @@
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true,
 			"optional": true
-		},
-		"async-retry": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-			"integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-			"dev": true,
-			"requires": {
-				"retry": "0.12.0"
-			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -4103,33 +3428,11 @@
 				"postcss-value-parser": "^4.1.0"
 			}
 		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
-			"dev": true
-		},
 		"axe-core": {
 			"version": "3.5.5",
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
 			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -4232,74 +3535,6 @@
 			"integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==",
 			"dev": true
 		},
-		"babel-jest": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
-			"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
-			"dev": true,
-			"requires": {
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
-				"@types/babel__core": "^7.1.7",
-				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^25.5.0",
-				"chalk": "^3.0.0",
-				"graceful-fs": "^4.2.4",
-				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"babel-loader": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -4370,17 +3605,6 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-instrument": "^4.0.0",
 				"test-exclude": "^6.0.0"
-			}
-		},
-		"babel-plugin-jest-hoist": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
-			"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__traverse": "^7.0.6"
 			}
 		},
 		"babel-plugin-macros": {
@@ -4488,12 +3712,6 @@
 				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
-		"babel-plugin-require-context-hook": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz",
-			"integrity": "sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==",
-			"dev": true
-		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -4571,35 +3789,6 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
 			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
 			"dev": true
-		},
-		"babel-preset-current-node-syntax": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
-			"dev": true,
-			"requires": {
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.8.3",
-				"@babel/plugin-syntax-import-meta": "^7.8.3",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
-			}
-		},
-		"babel-preset-jest": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
-			"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-jest-hoist": "^25.5.0",
-				"babel-preset-current-node-syntax": "^0.1.2"
-			}
 		},
 		"babel-preset-minify": {
 			"version": "0.5.1",
@@ -4710,15 +3899,6 @@
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
 			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
 			"dev": true
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"better-opn": {
 			"version": "2.0.0",
@@ -4915,29 +4095,6 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 			"dev": true
-		},
-		"browser-process-hrtime": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-			"dev": true
-		},
-		"browser-resolve": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				}
-			}
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -5214,17 +4371,6 @@
 			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"dev": true
 		},
-		"camelcase-keys": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
-			}
-		},
 		"caniuse-lite": {
 			"version": "1.0.30001113",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001113.tgz",
@@ -5244,12 +4390,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
 			"integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==",
-			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
 		"ccount": {
@@ -5314,110 +4454,6 @@
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"dev": true
-		},
-		"chromatic": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/chromatic/-/chromatic-5.1.0.tgz",
-			"integrity": "sha512-8hmRRayRKElR6+k4R1HZ3mq95zeJhzE2gxMQWrurbUl5tWG0n2JIuhsHS4vxnaFw/iVqMk10ORLtZ7StaHApUQ==",
-			"dev": true,
-			"requires": {
-				"@babel/preset-react": "^7.9.4",
-				"@babel/runtime": "^7.9.2",
-				"@chromaui/localtunnel": "2.0.1",
-				"async-retry": "^1.3.1",
-				"babel-plugin-require-context-hook": "^1.0.0",
-				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
-				"debug": "^4.1.1",
-				"dotenv": "^8.2.0",
-				"env-ci": "^5.0.2",
-				"esm": "^3.2.25",
-				"execa": "^4.0.0",
-				"fake-tag": "^2.0.0",
-				"fs-extra": "^9.0.0",
-				"jest": "^25.2.7",
-				"jsonfile": "^6.0.1",
-				"junit-report-builder": "2.0.0",
-				"listr": "0.14.3",
-				"meow": "^6.1.0",
-				"node-ask": "^1.0.1",
-				"node-fetch": "^2.6.0",
-				"node-loggly-bulk": "^2.2.4",
-				"p-limit": "2.3.0",
-				"picomatch": "2.2.2",
-				"pkg-up": "^3.1.0",
-				"pluralize": "^8.0.0",
-				"progress": "^2.0.3",
-				"progress-stream": "^2.0.0",
-				"semver": "^7.1.3",
-				"slash": "^3.0.0",
-				"strip-ansi": "6.0.0",
-				"tmp": "^0.1.0",
-				"tmp-promise": "2.1.1",
-				"tree-kill": "^1.2.2",
-				"ts-dedent": "^1.1.1",
-				"util-deprecate": "^1.0.2",
-				"uuid": "^7.0.3",
-				"yarn-or-npm": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -5502,15 +4538,6 @@
 			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
 			"dev": true
 		},
-		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "^2.0.0"
-			}
-		},
 		"cli-table3": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -5547,53 +4574,6 @@
 				}
 			}
 		},
-		"cli-truncate": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"dev": true,
-			"requires": {
-				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
 		"cli-width": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -5612,34 +4592,6 @@
 				"tiny-emitter": "^2.0.0"
 			}
 		},
-		"cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -5650,12 +4602,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
 			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-			"dev": true
-		},
-		"collect-v8-coverage": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -6042,29 +4988,6 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
 		},
-		"cssom": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-			"dev": true
-		},
-		"cssstyle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-			"dev": true,
-			"requires": {
-				"cssom": "~0.3.6"
-			},
-			"dependencies": {
-				"cssom": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-					"dev": true
-				}
-			}
-		},
 		"csstype": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
@@ -6077,38 +5000,6 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
-		"data-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-			"dev": true,
-			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
-			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
-		},
-		"date-format": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
-			"integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=",
-			"dev": true
-		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6116,30 +5007,6 @@
 			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
-			}
-		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
-		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				}
 			}
 		},
 		"decode-uri-component": {
@@ -6172,12 +5039,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
 			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
-			"dev": true
-		},
-		"deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
 		"define-properties": {
@@ -6280,12 +5141,6 @@
 				"repeat-string": "^1.5.4"
 			}
 		},
-		"detect-newline": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-			"dev": true
-		},
 		"detect-port": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
@@ -6312,12 +5167,6 @@
 					"dev": true
 				}
 			}
-		},
-		"diff-sequences": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -6418,15 +5267,6 @@
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
-		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
-			"requires": {
-				"webidl-conversions": "^4.0.2"
-			}
-		},
 		"domhandler": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
@@ -6512,16 +5352,6 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6541,12 +5371,6 @@
 			"version": "1.3.531",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.531.tgz",
 			"integrity": "sha512-cRdM9noPSUvZ2TCJByhFL78amPMjNZlGJG27EPuJZK0CwWzBfj3ei7hJh0hNsjvgC0BayRW8Bc06DTCELcMC9Q==",
-			"dev": true
-		},
-		"elegant-spinner": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
 			"dev": true
 		},
 		"element-resize-detector": {
@@ -6656,16 +5480,6 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
 			"dev": true
-		},
-		"env-ci": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
-			"integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
-			"dev": true,
-			"requires": {
-				"execa": "^4.0.0",
-				"java-properties": "^1.0.0"
-			}
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -7140,12 +5954,6 @@
 			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
-		"esm": {
-			"version": "3.2.25",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-			"dev": true
-		},
 		"espree": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
@@ -7229,29 +6037,6 @@
 			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
 			"dev": true
 		},
-		"execa": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-			"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.0",
-				"get-stream": "^5.0.0",
-				"human-signals": "^1.1.1",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.0",
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2",
-				"strip-final-newline": "^2.0.0"
-			}
-		},
-		"exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-			"dev": true
-		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -7298,47 +6083,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"expect": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
-			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"ansi-styles": "^4.0.0",
-				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-regex-util": "^25.2.6"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				}
 			}
@@ -7517,18 +6261,6 @@
 					}
 				}
 			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fake-tag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-2.0.0.tgz",
-			"integrity": "sha512-QDz+8qiNQ9AfBZ31EXlID5JIbUkU3e1nXDWk4tidFzd2gy8XJaEUW1HCuDY6DUy6t2Y0nvhD6PsUc+2WYy5w0w==",
-			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -7717,16 +6449,6 @@
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
 			"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
 			"dev": true
-		},
-		"figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
-			}
 		},
 		"file-entry-cache": {
 			"version": "5.0.1",
@@ -7930,42 +6652,10 @@
 				"readable-stream": "^2.3.6"
 			}
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"dev": true,
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
 		},
 		"fork-ts-checker-webpack-plugin": {
@@ -8092,17 +6782,6 @@
 						"repeat-string": "^1.6.1"
 					}
 				}
-			}
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
 			}
 		},
 		"format": {
@@ -8282,41 +6961,17 @@
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
 			"dev": true
 		},
-		"get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
 		"get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
-		"get-stream": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-			"dev": true,
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"github-slugger": {
 			"version": "1.3.0",
@@ -8516,13 +7171,6 @@
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
-		"growly": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true,
-			"optional": true
-		},
 		"gud": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -8538,28 +7186,6 @@
 				"duplexer": "^0.1.1",
 				"pify": "^4.0.1"
 			}
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
@@ -8827,25 +7453,10 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 			"dev": true
 		},
-		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
-			"requires": {
-				"whatwg-encoding": "^1.0.1"
-			}
-		},
 		"html-entities": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
 			"integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
-			"dev": true
-		},
-		"html-escaper": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"html-loader": {
@@ -9018,27 +7629,10 @@
 				}
 			}
 		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			}
-		},
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
-		},
-		"human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -9127,71 +7721,10 @@
 				}
 			}
 		},
-		"import-local": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-			"dev": true,
-			"requires": {
-				"pkg-dir": "^4.2.0",
-				"resolve-cwd": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				}
-			}
-		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
-		},
-		"indent-string": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
 			"dev": true
 		},
 		"indexes-of": {
@@ -9390,12 +7923,6 @@
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
 			"dev": true
 		},
-		"ip-regex": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-			"dev": true
-		},
 		"ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -9585,12 +8112,6 @@
 			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
 			"dev": true
 		},
-		"is-generator-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-			"dev": true
-		},
 		"is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -9618,21 +8139,6 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
-		"is-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"dev": true,
-			"requires": {
-				"symbol-observable": "^1.1.0"
-			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
-		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -9641,12 +8147,6 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
-		},
-		"is-promise": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-			"dev": true
 		},
 		"is-regex": {
 			"version": "1.1.1",
@@ -9667,12 +8167,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
 			"integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-			"dev": true
-		},
-		"is-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-string": {
@@ -9741,12 +8235,6 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -9771,78 +8259,6 @@
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
-			}
-		},
-		"istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
-			"dev": true,
-			"requires": {
-				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
-				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"istanbul-lib-source-maps": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"istanbul-reports": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
-			"dev": true,
-			"requires": {
-				"html-escaper": "^2.0.0",
-				"istanbul-lib-report": "^3.0.0"
 			}
 		},
 		"iterate-iterator": {
@@ -9873,1453 +8289,6 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"java-properties": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
-			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
-			"dev": true
-		},
-		"jest": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
-			"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
-			"dev": true,
-			"requires": {
-				"@jest/core": "^25.5.4",
-				"import-local": "^3.0.2",
-				"jest-cli": "^25.5.4"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"jest-cli": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
-					"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
-					"dev": true,
-					"requires": {
-						"@jest/core": "^25.5.4",
-						"@jest/test-result": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"import-local": "^3.0.2",
-						"is-ci": "^2.0.0",
-						"jest-config": "^25.5.4",
-						"jest-util": "^25.5.0",
-						"jest-validate": "^25.5.0",
-						"prompts": "^2.0.1",
-						"realpath-native": "^2.0.0",
-						"yargs": "^15.3.1"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"jest-changed-files": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
-			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"execa": "^3.2.0",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"execa": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-					"dev": true
-				}
-			}
-		},
-		"jest-config": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
-			"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^25.5.4",
-				"@jest/types": "^25.5.0",
-				"babel-jest": "^25.5.1",
-				"chalk": "^3.0.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.1",
-				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^25.5.0",
-				"jest-environment-node": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"jest-jasmine2": "^25.5.4",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
-				"micromatch": "^4.0.2",
-				"pretty-format": "^25.5.0",
-				"realpath-native": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-diff": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-			"dev": true,
-			"requires": {
-				"chalk": "^3.0.0",
-				"diff-sequences": "^25.2.6",
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-docblock": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
-			"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
-			"dev": true,
-			"requires": {
-				"detect-newline": "^3.0.0"
-			}
-		},
-		"jest-each": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
-			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.6",
-				"jest-util": "^25.5.0",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-environment-jsdom": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
-			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
-			"dev": true,
-			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"jsdom": "^15.2.1"
-			}
-		},
-		"jest-environment-node": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
-			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
-			"dev": true,
-			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"jest-get-type": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-			"dev": true
-		},
-		"jest-haste-map": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
-			"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"@types/graceful-fs": "^4.1.2",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-serializer": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
-				"micromatch": "^4.0.2",
-				"sane": "^4.0.3",
-				"walker": "^1.0.7",
-				"which": "^2.0.2"
-			}
-		},
-		"jest-jasmine2": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
-			"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
-			"dev": true,
-			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/source-map": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"co": "^4.6.0",
-				"expect": "^25.5.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^25.5.0",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-runtime": "^25.5.4",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"pretty-format": "^25.5.0",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-leak-detector": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
-			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
-			"dev": true,
-			"requires": {
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
-			}
-		},
-		"jest-matcher-utils": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
-			"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^3.0.0",
-				"jest-diff": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-message-util": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
-			"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^25.5.0",
-				"@types/stack-utils": "^1.0.1",
-				"chalk": "^3.0.0",
-				"graceful-fs": "^4.2.4",
-				"micromatch": "^4.0.2",
-				"slash": "^3.0.0",
-				"stack-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-mock": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
-			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0"
-			}
-		},
-		"jest-pnp-resolver": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true
-		},
-		"jest-regex-util": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-			"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
-			"dev": true
-		},
-		"jest-resolve": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
-			"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^3.0.0",
-				"graceful-fs": "^4.2.4",
-				"jest-pnp-resolver": "^1.2.1",
-				"read-pkg-up": "^7.0.1",
-				"realpath-native": "^2.0.0",
-				"resolve": "^1.17.0",
-				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
-			"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-snapshot": "^25.5.1"
-			}
-		},
-		"jest-runner": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
-			"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-config": "^25.5.4",
-				"jest-docblock": "^25.3.0",
-				"jest-haste-map": "^25.5.1",
-				"jest-jasmine2": "^25.5.4",
-				"jest-leak-detector": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-resolve": "^25.5.1",
-				"jest-runtime": "^25.5.4",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-runtime": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
-			"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/globals": "^25.5.2",
-				"@jest/source-map": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^3.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.4",
-				"jest-config": "^25.5.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-message-util": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
-				"realpath-native": "^2.0.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0",
-				"yargs": "^15.3.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"jest-serializer": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
-			"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.2.4"
-			}
-		},
-		"jest-snapshot": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
-			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0",
-				"@jest/types": "^25.5.0",
-				"@types/prettier": "^1.19.0",
-				"chalk": "^3.0.0",
-				"expect": "^25.5.0",
-				"graceful-fs": "^4.2.4",
-				"jest-diff": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-resolve": "^25.5.1",
-				"make-dir": "^3.0.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^25.5.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-util": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
-			"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"graceful-fs": "^4.2.4",
-				"is-ci": "^2.0.0",
-				"make-dir": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-validate": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
-			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.6",
-				"leven": "^3.1.0",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-watcher": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
-			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
-			"dev": true,
-			"requires": {
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
-				"jest-util": "^25.5.0",
-				"string-length": "^3.1.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-worker": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
-			"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
-			"dev": true,
-			"requires": {
-				"merge-stream": "^2.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -11342,51 +8311,11 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
 		"jsdoctypeparser": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
 			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
 			"dev": true
-		},
-		"jsdom": {
-			"version": "15.2.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-			"dev": true,
-			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^7.1.0",
-				"acorn-globals": "^4.3.2",
-				"array-equal": "^1.0.0",
-				"cssom": "^0.4.1",
-				"cssstyle": "^2.0.0",
-				"data-urls": "^1.1.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.11.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"nwsapi": "^2.2.0",
-				"parse5": "5.1.0",
-				"pn": "^1.1.0",
-				"request": "^2.88.0",
-				"request-promise-native": "^1.0.7",
-				"saxes": "^3.1.9",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^3.0.1",
-				"w3c-hr-time": "^1.0.1",
-				"w3c-xmlserializer": "^1.1.2",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.5",
-				"whatwg-mimetype": "^2.3.0",
-				"whatwg-url": "^7.0.0",
-				"ws": "^7.0.0",
-				"xml-name-validator": "^3.0.0"
-			}
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -11400,12 +8329,6 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -11416,12 +8339,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
 		"json5": {
@@ -11449,18 +8366,6 @@
 				"universalify": "^1.0.0"
 			}
 		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -11469,35 +8374,6 @@
 			"requires": {
 				"array-includes": "^3.1.1",
 				"object.assign": "^4.1.0"
-			}
-		},
-		"junit-report-builder": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-2.0.0.tgz",
-			"integrity": "sha512-/CkUScz5G7U1Fehna9swd8YfA+o5tV07NZz+3pea27okD0+ZEgyXQ5E0etyxMaqzXOjBvN8HGmNpVO/79yj5TA==",
-			"dev": true,
-			"requires": {
-				"date-format": "0.0.2",
-				"lodash": "^4.17.15",
-				"make-dir": "^1.3.0",
-				"xmlbuilder": "^10.0.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
 			}
 		},
 		"kind-of": {
@@ -11514,12 +8390,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.9"
 			}
-		},
-		"kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true
 		},
 		"lazy-universal-dotenv": {
 			"version": "3.0.1",
@@ -11564,118 +8434,6 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
 			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
 			"dev": true
-		},
-		"listr": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-			"dev": true,
-			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.5.0",
-				"listr-verbose-renderer": "^0.5.0",
-				"p-map": "^2.0.0",
-				"rxjs": "^6.3.3"
-			},
-			"dependencies": {
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				}
-			}
-		},
-		"listr-silent-renderer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-			"dev": true
-		},
-		"listr-update-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^2.3.0",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"listr-verbose-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"cli-cursor": "^2.1.0",
-				"date-fns": "^1.27.2",
-				"figures": "^2.0.0"
-			},
-			"dependencies": {
-				"figures": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				}
-			}
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -11757,131 +8515,11 @@
 			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
-		},
-		"log-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-			"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"log-update": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"cli-cursor": "^2.0.0",
-				"wrap-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0"
-					}
-				}
-			}
-		},
-		"lolex": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.7.0"
-			}
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -11943,12 +8581,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
-		},
-		"map-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-			"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
 			"dev": true
 		},
 		"map-or-similar": {
@@ -12085,43 +8717,6 @@
 			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
 			"dev": true
 		},
-		"meow": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
-			"integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
-			"dev": true,
-			"requires": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "^4.0.2",
-				"normalize-package-data": "^2.5.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.13.1",
-				"yargs-parser": "^18.1.3"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -12216,12 +8811,6 @@
 				"dom-walk": "^0.1.0"
 			}
 		},
-		"min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true
-		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -12248,17 +8837,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
-		},
-		"minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			}
 		},
 		"minipass": {
 			"version": "3.1.3",
@@ -12354,12 +8932,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"moment": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-			"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-			"dev": true
-		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -12450,12 +9022,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"node-ask": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
-			"integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=",
-			"dev": true
-		},
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -12507,55 +9073,11 @@
 				}
 			}
 		},
-		"node-loggly-bulk": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz",
-			"integrity": "sha512-DfhtsDfkSBU6Dp1zvK+H1MgHRcA2yb4z07ctyA6uo+bNwKtv1exhohN910zcWNkdSYq1TImCq+O+3bOTuYHvmQ==",
-			"dev": true,
-			"requires": {
-				"json-stringify-safe": "5.0.x",
-				"moment": "^2.18.1",
-				"request": ">=2.76.0 <3.0.0"
-			}
-		},
 		"node-modules-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
 			"dev": true
-		},
-		"node-notifier": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
-			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^2.1.1",
-				"semver": "^6.3.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true,
-					"optional": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
 		},
 		"node-releases": {
 			"version": "1.1.60",
@@ -12660,15 +9182,6 @@
 				}
 			}
 		},
-		"npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"requires": {
-				"path-key": "^3.0.0"
-			}
-		},
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -12700,18 +9213,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
-		},
-		"nwsapi": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
-			"dev": true
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"object-assign": {
@@ -12891,12 +9392,6 @@
 				"is-wsl": "^2.1.1"
 			}
 		},
-		"openurl": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-			"dev": true
-		},
 		"optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -12929,12 +9424,6 @@
 			"integrity": "sha512-p8oHrMeRAKxXDMPI/EBNITj/zTVHKNnAnM59Im+xnoZUlV07FyTg46wom2286jJlXGGfcPFG/ba5NUiCwWNd4w==",
 			"dev": true
 		},
-		"p-each-series": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-			"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
-			"dev": true
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12958,12 +9447,6 @@
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
-		},
-		"p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true
 		},
 		"p-try": {
 			"version": "2.2.0",
@@ -13050,12 +9533,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
 			"integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-			"dev": true
-		},
-		"parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
 			"dev": true
 		},
 		"parseurl": {
@@ -13152,12 +9629,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
-		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -13202,18 +9673,6 @@
 			"requires": {
 				"find-up": "^3.0.0"
 			}
-		},
-		"pluralize": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-			"dev": true
-		},
-		"pn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
 		},
 		"pnp-webpack-plugin": {
 			"version": "1.6.4",
@@ -13437,51 +9896,6 @@
 				"utila": "~0.4"
 			}
 		},
-		"pretty-format": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^25.5.0",
-				"ansi-regex": "^5.0.0",
-				"ansi-styles": "^4.0.0",
-				"react-is": "^16.12.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				}
-			}
-		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -13515,16 +9929,6 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
-		"progress-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
-			"integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
-			"dev": true,
-			"requires": {
-				"speedometer": "~1.0.0",
-				"through2": "~2.0.3"
-			}
-		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -13553,16 +9957,6 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.0",
 				"function-bind": "^1.1.1"
-			}
-		},
-		"prompts": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
-			"dev": true,
-			"requires": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.4"
 			}
 		},
 		"prop-types": {
@@ -13599,12 +9993,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"public-encrypt": {
@@ -13668,12 +10056,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
-		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -13684,12 +10066,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
-		},
-		"quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 			"dev": true
 		},
 		"ramda": {
@@ -14364,73 +10740,6 @@
 				"lodash": "^4.0.1"
 			}
 		},
-		"read-pkg": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-			"dev": true,
-			"requires": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^2.5.0",
-				"parse-json": "^5.0.0",
-				"type-fest": "^0.6.0"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-					"dev": true
-				}
-			}
-		},
-		"read-pkg-up": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-			"dev": true,
-			"requires": {
-				"find-up": "^4.1.0",
-				"read-pkg": "^5.2.0",
-				"type-fest": "^0.8.1"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				}
-			}
-		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -14455,12 +10764,6 @@
 				"picomatch": "^2.2.1"
 			}
 		},
-		"realpath-native": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-			"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-			"dev": true
-		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -14477,24 +10780,6 @@
 			"dev": true,
 			"requires": {
 				"minimatch": "3.0.4"
-			}
-		},
-		"redent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-			"dev": true,
-			"requires": {
-				"indent-string": "^4.0.0",
-				"strip-indent": "^3.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				}
 			}
 		},
 		"refractor": {
@@ -14821,96 +11106,6 @@
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
 			"dev": true
 		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"dev": true,
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
-			}
-		},
-		"request-promise-core": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.19"
-			}
-		},
-		"request-promise-native": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-			"dev": true,
-			"requires": {
-				"request-promise-core": "1.1.4",
-				"stealthy-require": "^1.1.1",
-				"tough-cookie": "^2.3.3"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"dev": true,
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
-				}
-			}
-		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -14918,15 +11113,6 @@
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
-			}
-		},
-		"resolve-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^5.0.0"
 			}
 		},
 		"resolve-from": {
@@ -14941,43 +11127,10 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
-		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
-			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
-			},
-			"dependencies": {
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
-				},
-				"onetime": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				}
-			}
-		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
-		},
-		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
 		"rimraf": {
@@ -15279,15 +11432,6 @@
 				}
 			}
 		},
-		"saxes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
-			"dev": true,
-			"requires": {
-				"xmlchars": "^2.1.1"
-			}
-		},
 		"scheduler": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -15513,13 +11657,6 @@
 				}
 			}
 		},
-		"shellwords": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true,
-			"optional": true
-		},
 		"side-channel": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -15536,22 +11673,10 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
-		"sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true
-		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
-		},
-		"slice-ansi": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
 		},
 		"snapdragon": {
@@ -15769,12 +11894,6 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
-		"speedometer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-			"integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI=",
-			"dev": true
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15790,23 +11909,6 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"ssri": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
@@ -15820,12 +11922,6 @@
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-			"dev": true
-		},
-		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
 		"state-toggle": {
@@ -15859,12 +11955,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
-		},
-		"stealthy-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
 		"store2": {
@@ -15911,27 +12001,6 @@
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
-		},
-		"string-length": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
-			"dev": true,
-			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^5.2.0"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
 		},
 		"string-width": {
 			"version": "3.1.0",
@@ -16035,32 +12104,11 @@
 				}
 			}
 		},
-		"strip-bom": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-			"dev": true
-		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
-		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true
-		},
-		"strip-indent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-			"dev": true,
-			"requires": {
-				"min-indent": "^1.0.0"
-			}
 		},
 		"strip-json-comments": {
 			"version": "3.1.1",
@@ -16108,45 +12156,6 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
-		},
-		"supports-hyperlinks": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
-		},
-		"symbol-tree": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-			"dev": true
 		},
 		"symbol.prototype.description": {
 			"version": "1.0.2",
@@ -16240,16 +12249,6 @@
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
 			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
 			"dev": true
-		},
-		"terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			}
 		},
 		"terser": {
 			"version": "4.8.0",
@@ -16433,12 +12432,6 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
-		"throat": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
-			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
-			"dev": true
-		},
 		"throttle-debounce": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
@@ -16482,35 +12475,6 @@
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
 			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
 			"dev": true
-		},
-		"tmp": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-			"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-			"dev": true,
-			"requires": {
-				"rimraf": "^2.6.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
-		"tmp-promise": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.1.1.tgz",
-			"integrity": "sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==",
-			"dev": true,
-			"requires": {
-				"tmp": "0.1.0"
-			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -16589,36 +12553,10 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
-		"tough-cookie": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-			"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-			"dev": true,
-			"requires": {
-				"ip-regex": "^2.1.0",
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
-		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
 		"traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-		},
-		"tree-kill": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-			"dev": true
 		},
 		"trim": {
 			"version": "0.0.1",
@@ -16630,12 +12568,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
 			"integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-			"dev": true
-		},
-		"trim-newlines": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-			"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
 			"dev": true
 		},
 		"trim-trailing-lines": {
@@ -16680,21 +12612,6 @@
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
-		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -16703,12 +12620,6 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
-		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
 		},
 		"type-fest": {
 			"version": "0.8.1",
@@ -17117,36 +13028,11 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
 			"dev": true
 		},
-		"uuid": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-			"dev": true
-		},
 		"v8-compile-cache": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
 			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
-		},
-		"v8-to-istanbul": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
-			"integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
-			"dev": true,
-			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0",
-				"source-map": "^0.7.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
-				}
-			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -17163,17 +13049,6 @@
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
 			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
 		},
 		"vfile": {
 			"version": "4.2.0",
@@ -17272,26 +13147,6 @@
 						"eslint-visitor-keys": "^1.1.0"
 					}
 				}
-			}
-		},
-		"w3c-hr-time": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-			"integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-			"dev": true,
-			"requires": {
-				"browser-process-hrtime": "^1.0.0"
-			}
-		},
-		"w3c-xmlserializer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
-			"dev": true,
-			"requires": {
-				"domexception": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -17561,12 +13416,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
 			"integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
-			"dev": true
-		},
-		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"webpack": {
@@ -17941,32 +13790,6 @@
 				}
 			}
 		},
-		"whatwg-encoding": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-			"dev": true,
-			"requires": {
-				"iconv-lite": "0.4.24"
-			}
-		},
-		"whatwg-mimetype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-			"dev": true
-		},
-		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-			"dev": true,
-			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
-			}
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -17975,12 +13798,6 @@
 			"requires": {
 				"isexe": "^2.0.0"
 			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
@@ -18076,28 +13893,6 @@
 				"microevent.ts": "~0.1.1"
 			}
 		},
-		"wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -18125,30 +13920,6 @@
 				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
-		"ws": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-			"dev": true
-		},
-		"xml-name-validator": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
-		},
-		"xmlbuilder": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
-			"integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
-			"dev": true
-		},
-		"xmlchars": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true
-		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -18172,132 +13943,6 @@
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
 			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
 			"dev": true
-		},
-		"yargs": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-			"dev": true,
-			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.2"
-			}
-		},
-		"yargs-parser": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		},
-		"yarn-or-npm": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/yarn-or-npm/-/yarn-or-npm-3.0.1.tgz",
-			"integrity": "sha512-fTiQP6WbDAh5QZAVdbMQkecZoahnbOjClTQhzv74WX5h2Uaidj1isf9FDes11TKtsZ0/ZVfZsqZ+O3x6aLERHQ==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^6.0.5",
-				"pkg-dir": "^4.2.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
 		},
 		"zwitch": {
 			"version": "1.0.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,8 +22,7 @@
     "test": "npm-run-all test:*",
     "test:lint": "eslint . --ext .js --ext .jsx",
     "fix": "npm run test:lint -- --fix",
-    "build": "build-storybook -o dist",
-    "chromatic": "npx chromatic build --project-token=3evi132fpys --storybook-build-dir dist"
+    "build": "build-storybook -o dist"
   },
   "dependencies": {
     "@wmde/wikit-tokens": "^0.0.0",
@@ -41,7 +40,6 @@
     "@storybook/addon-knobs": "^6.0.4",
     "@storybook/html": "^6.0.4",
     "babel-loader": "^8.1.0",
-    "chromatic": "^5.0.0",
     "eslint": "^7.3.1",
     "eslint-config-wikimedia": "^0.16.2",
     "eslint-plugin-react": "^7.20.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:storybook:vue-components": "lerna run build:storybook --scope @wmde/wikit-vue-components",
     "build:storybook:extract-stories": "lerna run build:extract-stories --scope @wmde/wikit-vue-components",
     "build:storybook:compose": "cp -r vue-components/storybook-static docs/dist/vue-components",
-    "chromatic": "lerna run chromatic --scope @wmde/wikit-docs"
+    "chromatic": "lerna run chromatic --scope @wmde/wikit-vue-components"
   },
   "devDependencies": {
     "lerna": "^3.22.1",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -476,6 +476,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
 		"@babel/plugin-syntax-class-properties": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
@@ -521,6 +530,15 @@
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
 		"@babel/plugin-syntax-json-strings": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -534,6 +552,15 @@
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
 			"integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -1198,6 +1225,85 @@
 			"integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
 			"dev": true
 		},
+		"@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"@chromaui/localtunnel": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@chromaui/localtunnel/-/localtunnel-2.0.1.tgz",
+			"integrity": "sha512-QvO1J9drc7K2SeBrHuO5/8nQ1QTks/OOG+vwva4lM7T28pPgf556snMpPE/3KE6uD2UJky8I4A5dNRNbqAXiDw==",
+			"dev": true,
+			"requires": {
+				"axios": "0.19.0",
+				"debug": "^3.0.1",
+				"openurl": "^1.1.1",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"axios": {
+					"version": "0.19.0",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+					"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+					"dev": true,
+					"requires": {
+						"follow-redirects": "1.5.10",
+						"is-buffer": "^2.0.2"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+							"dev": true
+						}
+					}
+				},
+				"follow-redirects": {
+					"version": "1.5.10",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+					"dev": true,
+					"requires": {
+						"debug": "=3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1543,6 +1649,305 @@
 				"jest-mock": "^24.9.0"
 			}
 		},
+		"@jest/globals": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"expect": "^25.5.0"
+			},
+			"dependencies": {
+				"@jest/environment": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+					"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"jest-mock": "^25.5.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+					"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-mock": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"lolex": "^5.0.0"
+					}
+				},
+				"@jest/types": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+					"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+					"dev": true
+				},
+				"expect": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+					"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-styles": "^4.0.0",
+						"jest-get-type": "^25.2.6",
+						"jest-matcher-utils": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-regex-util": "^25.2.6"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+					"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"diff-sequences": "^25.2.6",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+					"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+					"dev": true
+				},
+				"jest-matcher-utils": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+					"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"jest-diff": "^25.5.0",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					}
+				},
+				"jest-message-util": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+					"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/types": "^25.5.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"micromatch": "^4.0.2",
+						"slash": "^3.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+					"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0"
+					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
+				},
+				"jest-util": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+					"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"is-ci": "^2.0.0",
+						"make-dir": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"pretty-format": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+					"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
 		"@jest/reporters": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
@@ -1801,11 +2206,37 @@
 				"react-lifecycles-compat": "^3.0.4"
 			}
 		},
+		"@samverschueren/stream-to-observable": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+			"integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
+			"dev": true,
+			"requires": {
+				"any-observable": "^0.3.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
 			"dev": true
+		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+					"dev": true
+				}
+			}
 		},
 		"@soda/friendly-errors-webpack-plugin": {
 			"version": "1.7.1",
@@ -3782,6 +4213,12 @@
 			"integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
 			"dev": true
 		},
+		"@types/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+			"dev": true
+		},
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -5187,6 +5624,12 @@
 				}
 			}
 		},
+		"any-observable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+			"dev": true
+		},
 		"any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -5481,6 +5924,15 @@
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
 			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
+		},
+		"async-retry": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+			"integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+			"dev": true,
+			"requires": {
+				"retry": "0.12.0"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -5921,6 +6373,12 @@
 				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
+		"babel-plugin-require-context-hook": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz",
+			"integrity": "sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==",
+			"dev": true
+		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -6020,6 +6478,25 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
 			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
 			"dev": true
+		},
+		"babel-preset-current-node-syntax": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
 		},
 		"babel-preset-jest": {
 			"version": "24.9.0",
@@ -7440,6 +7917,1759 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
+		"chromatic": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/chromatic/-/chromatic-5.1.0.tgz",
+			"integrity": "sha512-8hmRRayRKElR6+k4R1HZ3mq95zeJhzE2gxMQWrurbUl5tWG0n2JIuhsHS4vxnaFw/iVqMk10ORLtZ7StaHApUQ==",
+			"dev": true,
+			"requires": {
+				"@babel/preset-react": "^7.9.4",
+				"@babel/runtime": "^7.9.2",
+				"@chromaui/localtunnel": "2.0.1",
+				"async-retry": "^1.3.1",
+				"babel-plugin-require-context-hook": "^1.0.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.1.1",
+				"dotenv": "^8.2.0",
+				"env-ci": "^5.0.2",
+				"esm": "^3.2.25",
+				"execa": "^4.0.0",
+				"fake-tag": "^2.0.0",
+				"fs-extra": "^9.0.0",
+				"jest": "^25.2.7",
+				"jsonfile": "^6.0.1",
+				"junit-report-builder": "2.0.0",
+				"listr": "0.14.3",
+				"meow": "^6.1.0",
+				"node-ask": "^1.0.1",
+				"node-fetch": "^2.6.0",
+				"node-loggly-bulk": "^2.2.4",
+				"p-limit": "2.3.0",
+				"picomatch": "2.2.2",
+				"pkg-up": "^3.1.0",
+				"pluralize": "^8.0.0",
+				"progress": "^2.0.3",
+				"progress-stream": "^2.0.0",
+				"semver": "^7.1.3",
+				"slash": "^3.0.0",
+				"strip-ansi": "6.0.0",
+				"tmp": "^0.1.0",
+				"tmp-promise": "2.1.1",
+				"tree-kill": "^1.2.2",
+				"ts-dedent": "^1.1.1",
+				"util-deprecate": "^1.0.2",
+				"uuid": "^7.0.3",
+				"yarn-or-npm": "^3.0.1"
+			},
+			"dependencies": {
+				"@jest/console": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
+					"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"jest-message-util": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"@jest/core": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
+					"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^25.5.0",
+						"@jest/reporters": "^25.5.1",
+						"@jest/test-result": "^25.5.0",
+						"@jest/transform": "^25.5.1",
+						"@jest/types": "^25.5.0",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^3.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-changed-files": "^25.5.0",
+						"jest-config": "^25.5.4",
+						"jest-haste-map": "^25.5.1",
+						"jest-message-util": "^25.5.0",
+						"jest-regex-util": "^25.2.6",
+						"jest-resolve": "^25.5.1",
+						"jest-resolve-dependencies": "^25.5.4",
+						"jest-runner": "^25.5.4",
+						"jest-runtime": "^25.5.4",
+						"jest-snapshot": "^25.5.1",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
+						"jest-watcher": "^25.5.0",
+						"micromatch": "^4.0.2",
+						"p-each-series": "^2.1.0",
+						"realpath-native": "^2.0.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"@jest/environment": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+					"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"jest-mock": "^25.5.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+					"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-mock": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"lolex": "^5.0.0"
+					}
+				},
+				"@jest/reporters": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
+					"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
+					"dev": true,
+					"requires": {
+						"@bcoe/v8-coverage": "^0.2.3",
+						"@jest/console": "^25.5.0",
+						"@jest/test-result": "^25.5.0",
+						"@jest/transform": "^25.5.1",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.2.4",
+						"istanbul-lib-coverage": "^3.0.0",
+						"istanbul-lib-instrument": "^4.0.0",
+						"istanbul-lib-report": "^3.0.0",
+						"istanbul-lib-source-maps": "^4.0.0",
+						"istanbul-reports": "^3.0.2",
+						"jest-haste-map": "^25.5.1",
+						"jest-resolve": "^25.5.1",
+						"jest-util": "^25.5.0",
+						"jest-worker": "^25.5.0",
+						"node-notifier": "^6.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^3.1.0",
+						"terminal-link": "^2.0.0",
+						"v8-to-istanbul": "^4.1.3"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"@jest/source-map": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+					"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+					"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"collect-v8-coverage": "^1.0.0"
+					}
+				},
+				"@jest/test-sequencer": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
+					"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^25.5.0",
+						"graceful-fs": "^4.2.4",
+						"jest-haste-map": "^25.5.1",
+						"jest-runner": "^25.5.4",
+						"jest-runtime": "^25.5.4"
+					}
+				},
+				"@jest/transform": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
+					"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/types": "^25.5.0",
+						"babel-plugin-istanbul": "^6.0.0",
+						"chalk": "^3.0.0",
+						"convert-source-map": "^1.4.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.2.4",
+						"jest-haste-map": "^25.5.1",
+						"jest-regex-util": "^25.2.6",
+						"jest-util": "^25.5.0",
+						"micromatch": "^4.0.2",
+						"pirates": "^4.0.1",
+						"realpath-native": "^2.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.1",
+						"write-file-atomic": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"@jest/types": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"acorn": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+					"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"babel-jest": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+					"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+					"dev": true,
+					"requires": {
+						"@jest/transform": "^25.5.1",
+						"@jest/types": "^25.5.0",
+						"@types/babel__core": "^7.1.7",
+						"babel-plugin-istanbul": "^6.0.0",
+						"babel-preset-jest": "^25.5.0",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"babel-plugin-istanbul": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+					"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@istanbuljs/load-nyc-config": "^1.0.0",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-instrument": "^4.0.0",
+						"test-exclude": "^6.0.0"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+					"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.3.3",
+						"@babel/types": "^7.3.3",
+						"@types/babel__traverse": "^7.0.6"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+					"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+					"dev": true,
+					"requires": {
+						"babel-plugin-jest-hoist": "^25.5.0",
+						"babel-preset-current-node-syntax": "^0.1.2"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"cssom": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+					"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+					"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+					"dev": true,
+					"requires": {
+						"cssom": "~0.3.6"
+					},
+					"dependencies": {
+						"cssom": {
+							"version": "0.3.8",
+							"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+							"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+							"dev": true
+						}
+					}
+				},
+				"detect-newline": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+					"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+					"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+					"dev": true
+				},
+				"execa": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"expect": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+					"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-styles": "^4.0.0",
+						"jest-get-type": "^25.2.6",
+						"jest-matcher-utils": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-regex-util": "^25.2.6"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"fs-extra": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"import-local": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"dev": true,
+					"requires": {
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
+					}
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+					"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+					"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^3.0.0",
+						"make-dir": "^3.0.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+					"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^3.0.0",
+						"source-map": "^0.6.1"
+					}
+				},
+				"istanbul-reports": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+					"dev": true,
+					"requires": {
+						"html-escaper": "^2.0.0",
+						"istanbul-lib-report": "^3.0.0"
+					}
+				},
+				"jest": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
+					"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^25.5.4",
+						"import-local": "^3.0.2",
+						"jest-cli": "^25.5.4"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						},
+						"jest-cli": {
+							"version": "25.5.4",
+							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
+							"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
+							"dev": true,
+							"requires": {
+								"@jest/core": "^25.5.4",
+								"@jest/test-result": "^25.5.0",
+								"@jest/types": "^25.5.0",
+								"chalk": "^3.0.0",
+								"exit": "^0.1.2",
+								"graceful-fs": "^4.2.4",
+								"import-local": "^3.0.2",
+								"is-ci": "^2.0.0",
+								"jest-config": "^25.5.4",
+								"jest-util": "^25.5.0",
+								"jest-validate": "^25.5.0",
+								"prompts": "^2.0.1",
+								"realpath-native": "^2.0.0",
+								"yargs": "^15.3.1"
+							}
+						}
+					}
+				},
+				"jest-changed-files": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+					"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"execa": "^3.2.0",
+						"throat": "^5.0.0"
+					},
+					"dependencies": {
+						"execa": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+							"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+							"dev": true,
+							"requires": {
+								"cross-spawn": "^7.0.0",
+								"get-stream": "^5.0.0",
+								"human-signals": "^1.1.1",
+								"is-stream": "^2.0.0",
+								"merge-stream": "^2.0.0",
+								"npm-run-path": "^4.0.0",
+								"onetime": "^5.1.0",
+								"p-finally": "^2.0.0",
+								"signal-exit": "^3.0.2",
+								"strip-final-newline": "^2.0.0"
+							}
+						}
+					}
+				},
+				"jest-config": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+					"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^25.5.4",
+						"@jest/types": "^25.5.0",
+						"babel-jest": "^25.5.1",
+						"chalk": "^3.0.0",
+						"deepmerge": "^4.2.2",
+						"glob": "^7.1.1",
+						"graceful-fs": "^4.2.4",
+						"jest-environment-jsdom": "^25.5.0",
+						"jest-environment-node": "^25.5.0",
+						"jest-get-type": "^25.2.6",
+						"jest-jasmine2": "^25.5.4",
+						"jest-regex-util": "^25.2.6",
+						"jest-resolve": "^25.5.1",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
+						"micromatch": "^4.0.2",
+						"pretty-format": "^25.5.0",
+						"realpath-native": "^2.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-diff": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+					"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"diff-sequences": "^25.2.6",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-docblock": {
+					"version": "25.3.0",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+					"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
+					"dev": true,
+					"requires": {
+						"detect-newline": "^3.0.0"
+					}
+				},
+				"jest-each": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+					"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"jest-get-type": "^25.2.6",
+						"jest-util": "^25.5.0",
+						"pretty-format": "^25.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+					"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^25.5.0",
+						"@jest/fake-timers": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"jest-mock": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"jsdom": "^15.2.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+					"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^25.5.0",
+						"@jest/fake-timers": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"jest-mock": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"jest-get-type": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+					"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+					"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"@types/graceful-fs": "^4.1.2",
+						"anymatch": "^3.0.3",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^2.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-serializer": "^25.5.0",
+						"jest-util": "^25.5.0",
+						"jest-worker": "^25.5.0",
+						"micromatch": "^4.0.2",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7",
+						"which": "^2.0.2"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
+					"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^25.5.0",
+						"@jest/source-map": "^25.5.0",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"co": "^4.6.0",
+						"expect": "^25.5.0",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^25.5.0",
+						"jest-matcher-utils": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-runtime": "^25.5.4",
+						"jest-snapshot": "^25.5.1",
+						"jest-util": "^25.5.0",
+						"pretty-format": "^25.5.0",
+						"throat": "^5.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-leak-detector": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+					"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
+					"dev": true,
+					"requires": {
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+					"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"jest-diff": "^25.5.0",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-message-util": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+					"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/types": "^25.5.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"micromatch": "^4.0.2",
+						"slash": "^3.0.0",
+						"stack-utils": "^1.0.1"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-mock": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+					"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0"
+					}
+				},
+				"jest-regex-util": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+					"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
+					"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"jest-pnp-resolver": "^1.2.1",
+						"read-pkg-up": "^7.0.1",
+						"realpath-native": "^2.0.0",
+						"resolve": "^1.17.0",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-resolve-dependencies": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
+					"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"jest-regex-util": "^25.2.6",
+						"jest-snapshot": "^25.5.1"
+					}
+				},
+				"jest-runner": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
+					"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^25.5.0",
+						"@jest/environment": "^25.5.0",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^25.5.4",
+						"jest-docblock": "^25.3.0",
+						"jest-haste-map": "^25.5.1",
+						"jest-jasmine2": "^25.5.4",
+						"jest-leak-detector": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-resolve": "^25.5.1",
+						"jest-runtime": "^25.5.4",
+						"jest-util": "^25.5.0",
+						"jest-worker": "^25.5.0",
+						"source-map-support": "^0.5.6",
+						"throat": "^5.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-runtime": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
+					"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^25.5.0",
+						"@jest/environment": "^25.5.0",
+						"@jest/globals": "^25.5.2",
+						"@jest/source-map": "^25.5.0",
+						"@jest/test-result": "^25.5.0",
+						"@jest/transform": "^25.5.1",
+						"@jest/types": "^25.5.0",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^25.5.4",
+						"jest-haste-map": "^25.5.1",
+						"jest-message-util": "^25.5.0",
+						"jest-mock": "^25.5.0",
+						"jest-regex-util": "^25.2.6",
+						"jest-resolve": "^25.5.1",
+						"jest-snapshot": "^25.5.1",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
+						"realpath-native": "^2.0.0",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.3.1"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-serializer": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+					"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.4"
+					}
+				},
+				"jest-snapshot": {
+					"version": "25.5.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+					"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^25.5.0",
+						"@types/prettier": "^1.19.0",
+						"chalk": "^3.0.0",
+						"expect": "^25.5.0",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^25.5.0",
+						"jest-get-type": "^25.2.6",
+						"jest-matcher-utils": "^25.5.0",
+						"jest-message-util": "^25.5.0",
+						"jest-resolve": "^25.5.1",
+						"make-dir": "^3.0.0",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^25.5.0",
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						},
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"jest-util": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+					"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"graceful-fs": "^4.2.4",
+						"is-ci": "^2.0.0",
+						"make-dir": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-validate": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+					"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"camelcase": "^5.3.1",
+						"chalk": "^3.0.0",
+						"jest-get-type": "^25.2.6",
+						"leven": "^3.1.0",
+						"pretty-format": "^25.5.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-watcher": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+					"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^3.0.0",
+						"jest-util": "^25.5.0",
+						"string-length": "^3.1.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"jest-worker": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+					"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
+				"jsdom": {
+					"version": "15.2.1",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+					"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^7.1.0",
+						"acorn-globals": "^4.3.2",
+						"array-equal": "^1.0.0",
+						"cssom": "^0.4.1",
+						"cssstyle": "^2.0.0",
+						"data-urls": "^1.1.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.11.1",
+						"html-encoding-sniffer": "^1.0.2",
+						"nwsapi": "^2.2.0",
+						"parse5": "5.1.0",
+						"pn": "^1.1.0",
+						"request": "^2.88.0",
+						"request-promise-native": "^1.0.7",
+						"saxes": "^3.1.9",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^3.0.1",
+						"w3c-hr-time": "^1.0.1",
+						"w3c-xmlserializer": "^1.1.2",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^7.0.0",
+						"ws": "^7.0.0",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"meow": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
+					"integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "^4.0.2",
+						"normalize-package-data": "^2.5.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.13.1",
+						"yargs-parser": "^18.1.3"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.13.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+							"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+							"dev": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"node-notifier": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+					"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"growly": "^1.3.0",
+						"is-wsl": "^2.1.1",
+						"semver": "^6.3.0",
+						"shellwords": "^0.1.1",
+						"which": "^1.3.1"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true,
+							"optional": true
+						},
+						"which": {
+							"version": "1.3.1",
+							"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+							"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"p-each-series": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+					"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+					"dev": true
+				},
+				"p-finally": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+					"dev": true
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"parse5": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"pretty-format": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+					"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"realpath-native": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+					"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+					"dev": true
+				},
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"dev": true,
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"string-length": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+					"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+					"dev": true,
+					"requires": {
+						"astral-regex": "^1.0.0",
+						"strip-ansi": "^5.2.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"test-exclude": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+					"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+					"dev": true,
+					"requires": {
+						"@istanbuljs/schema": "^0.1.2",
+						"glob": "^7.1.4",
+						"minimatch": "^3.0.4"
+					}
+				},
+				"throat": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+					"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+					"dev": true
+				},
+				"tmp": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
+					"requires": {
+						"rimraf": "^2.6.3"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.7.1",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+							"dev": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						}
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"tough-cookie": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+					"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+					"dev": true,
+					"requires": {
+						"ip-regex": "^2.1.0",
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
+					}
+				},
+				"ws": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -7891,6 +10121,59 @@
 				"string-width": "^4.2.0"
 			}
 		},
+		"cli-truncate": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+			"dev": true,
+			"requires": {
+				"slice-ansi": "0.0.4",
+				"string-width": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"slice-ansi": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
 		"cli-width": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -8027,6 +10310,12 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
 			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+			"dev": true
+		},
+		"collect-v8-coverage": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -8921,6 +11210,18 @@
 					}
 				}
 			}
+		},
+		"date-fns": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+			"dev": true
+		},
+		"date-format": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
+			"integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=",
+			"dev": true
 		},
 		"de-indent": {
 			"version": "1.0.2",
@@ -9928,6 +12229,12 @@
 			"integrity": "sha512-W1hGwaQEU8j9su2jeAr3aabkPuuXw+j8t73eajGAkEJWbfWiwbxBwQN/8Qmv2qCy3uCDm2rOAaZneYQM8VGC4w==",
 			"dev": true
 		},
+		"elegant-spinner": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+			"dev": true
+		},
 		"element-resize-detector": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.1.tgz",
@@ -10043,6 +12350,115 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
 			"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
 			"dev": true
+		},
+		"env-ci": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
+			"integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+			"dev": true,
+			"requires": {
+				"execa": "^4.0.0",
+				"java-properties": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
 		},
 		"envinfo": {
 			"version": "7.7.2",
@@ -11214,6 +13630,12 @@
 			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
+		},
 		"espree": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
@@ -11662,6 +14084,12 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fake-tag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-2.0.0.tgz",
+			"integrity": "sha512-QDz+8qiNQ9AfBZ31EXlID5JIbUkU3e1nXDWk4tidFzd2gy8XJaEUW1HCuDY6DUy6t2Y0nvhD6PsUc+2WYy5w0w==",
 			"dev": true
 		},
 		"fast-deep-equal": {
@@ -13971,6 +16399,15 @@
 			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
 			"dev": true
 		},
+		"is-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "^1.1.0"
+			}
+		},
 		"is-path-cwd": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -14294,6 +16731,12 @@
 					"dev": true
 				}
 			}
+		},
+		"java-properties": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+			"dev": true
 		},
 		"javascript-stringify": {
 			"version": "2.0.1",
@@ -15232,6 +17675,35 @@
 				"promise": "^7.0.1"
 			}
 		},
+		"junit-report-builder": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-2.0.0.tgz",
+			"integrity": "sha512-/CkUScz5G7U1Fehna9swd8YfA+o5tV07NZz+3pea27okD0+ZEgyXQ5E0etyxMaqzXOjBvN8HGmNpVO/79yj5TA==",
+			"dev": true,
+			"requires": {
+				"date-format": "0.0.2",
+				"lodash": "^4.17.15",
+				"make-dir": "^1.3.0",
+				"xmlbuilder": "^10.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -15348,6 +17820,143 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
 			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
 			"dev": true
+		},
+		"listr": {
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+			"dev": true,
+			"requires": {
+				"@samverschueren/stream-to-observable": "^0.3.0",
+				"is-observable": "^1.1.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.5.0",
+				"listr-verbose-renderer": "^0.5.0",
+				"p-map": "^2.0.0",
+				"rxjs": "^6.3.3"
+			},
+			"dependencies": {
+				"p-map": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+					"dev": true
+				}
+			}
+		},
+		"listr-silent-renderer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+			"dev": true
+		},
+		"listr-update-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^2.3.0",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"listr-verbose-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"cli-cursor": "^2.1.0",
+				"date-fns": "^1.27.2",
+				"figures": "^2.0.0"
+			},
+			"dependencies": {
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				}
+			}
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -15649,11 +18258,80 @@
 				"chalk": "^2.0.1"
 			}
 		},
+		"log-update": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"cli-cursor": "^2.0.0",
+				"wrap-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					}
+				}
+			}
+		},
 		"loglevel": {
 			"version": "1.6.8",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
 			"integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
 			"dev": true
+		},
+		"lolex": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
 		},
 		"longest-streak": {
 			"version": "2.0.4",
@@ -16467,6 +19145,12 @@
 				}
 			}
 		},
+		"moment": {
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+			"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+			"dev": true
+		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -16746,6 +19430,12 @@
 			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
 			"dev": true
 		},
+		"node-ask": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
+			"integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=",
+			"dev": true
+		},
 		"node-cache": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
@@ -16850,6 +19540,17 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				}
+			}
+		},
+		"node-loggly-bulk": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz",
+			"integrity": "sha512-DfhtsDfkSBU6Dp1zvK+H1MgHRcA2yb4z07ctyA6uo+bNwKtv1exhohN910zcWNkdSYq1TImCq+O+3bOTuYHvmQ==",
+			"dev": true,
+			"requires": {
+				"json-stringify-safe": "5.0.x",
+				"moment": "^2.18.1",
+				"request": ">=2.76.0 <3.0.0"
 			}
 		},
 		"node-modules-regexp": {
@@ -17223,6 +19924,12 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
 			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"dev": true
+		},
+		"openurl": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
 			"dev": true
 		},
 		"opn": {
@@ -17747,6 +20454,12 @@
 			"requires": {
 				"find-up": "^3.0.0"
 			}
+		},
+		"pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true
 		},
 		"pn": {
 			"version": "1.1.0",
@@ -18631,6 +21344,16 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
+		},
+		"progress-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+			"integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+			"dev": true,
+			"requires": {
+				"speedometer": "~1.0.0",
+				"through2": "~2.0.3"
+			}
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -21519,6 +24242,12 @@
 			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
 			"dev": true
 		},
+		"speedometer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+			"integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI=",
+			"dev": true
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -22236,6 +24965,33 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"supports-hyperlinks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"svg-tags": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -22262,6 +25018,12 @@
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.4",
@@ -22460,6 +25222,16 @@
 			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
 			"dev": true
 		},
+		"terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
+			}
+		},
 		"terser": {
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -22645,6 +25417,26 @@
 				"os-tmpdir": "~1.0.2"
 			}
 		},
+		"tmp-promise": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.1.1.tgz",
+			"integrity": "sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==",
+			"dev": true,
+			"requires": {
+				"tmp": "0.1.0"
+			},
+			"dependencies": {
+				"tmp": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
+					"requires": {
+						"rimraf": "^2.6.3"
+					}
+				}
+			}
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -22753,6 +25545,12 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true
 		},
 		"trim": {
 			"version": "0.0.1",
@@ -23561,6 +26359,25 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
 			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
+		},
+		"v8-to-istanbul": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+			"integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^1.6.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
+			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -24683,6 +27500,12 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
+		"xmlbuilder": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+			"integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+			"dev": true
+		},
 		"xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -24791,6 +27614,61 @@
 				"flat": "^4.1.0",
 				"lodash": "^4.17.15",
 				"yargs": "^13.3.0"
+			}
+		},
+		"yarn-or-npm": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/yarn-or-npm/-/yarn-or-npm-3.0.1.tgz",
+			"integrity": "sha512-fTiQP6WbDAh5QZAVdbMQkecZoahnbOjClTQhzv74WX5h2Uaidj1isf9FDes11TKtsZ0/ZVfZsqZ+O3x6aLERHQ==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.5",
+				"pkg-dir": "^4.2.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				}
 			}
 		},
 		"yauzl": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -18,7 +18,8 @@
     "storybook": "start-storybook",
     "test": "npm-run-all test:*",
     "test:lint": "vue-cli-service lint --no-fix",
-    "test:lintcss": "stylelint '**/*.vue'"
+    "test:lintcss": "stylelint '**/*.vue'",
+    "chromatic": "npx chromatic build --project-token=3evi132fpys --build-script-name=build:storybook"
   },
   "main": "dist/index.js",
   "files": [
@@ -49,6 +50,7 @@
     "@vue/eslint-config-typescript": "^5.0.2",
     "@vue/test-utils": "^1.0.3",
     "@wmde/eslint-config-wikimedia-typescript": "^0.2.0",
+    "chromatic": "^5.0.0",
     "chromedriver": "83",
     "eslint": "^7.2.0",
     "eslint-config-wikimedia": "^0.16.2",

--- a/vue-components/tests/e2e/custom-commands/openComponentStory.js
+++ b/vue-components/tests/e2e/custom-commands/openComponentStory.js
@@ -3,13 +3,9 @@ module.exports.command = function openComponentStory( component ) {
 		.click( `a[href="#${component}"]` )
 		.element(
 			'id',
-			'storybook-ref-vue',
+			'storybook-preview-iframe',
 			( { value } ) => {
-				if ( value && !value.error ) {
-					this.frame( value ); // storybook composition
-				} else {
-					this.frame( 'storybook-preview-iframe' ); // vue-components storybook, no composition
-				}
+				this.frame( value );
 			},
 		);
 };


### PR DESCRIPTION
### Explore how component changes affect chromatic [T257826](https://phabricator.wikimedia.org/T257826) 

After enabling the UI Review and Visual Tests options on Chromatic, it became clear that they don't work on our composed Storybook, whose main stories are the design system tokens.
After discussing this with UX, we agreed that it's more important to leverage the features Chromatic offers on our vue components and not on our design tokens.

This PR moves chromatic from the `docs` package to the `vue-components` package.
:heavy_plus_sign: This means the per-branch generated Chromatic URLs will show only the vue components Storybook. It will enable us to run visual tests and use the UI Review feature.
:heavy_plus_sign: This also means the browser tests no longer need to make a difference between a composed storybook and a local vue components storybook.
:heavy_minus_sign: The downside is that any token changes cannot be previewed on Chromatic anymore. This can only happen locally. 