### PR TITLE
vue-components: Add Safari on macOS to the browser tests config

### DIFF
--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -77,5 +77,14 @@ module.exports = {
 				version: 'latest',
 			},
 		},
+
+		sauceSafari: {
+			extends: 'sauceLabs',
+			desiredCapabilities: {
+				browserName: 'safari',
+				browserVersion: 'latest',
+				platformName: 'macOS 10.14',
+			},
+		},
 	},
 };


### PR DESCRIPTION
This PR adds one more browser config to our sauce labs tests - Safari on macOS.