### PR TITLE
tokens: add watcher for rebuilding during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ docker-compose up
 ¹ Please refer to the `.env` file(s) for port configuration.
 
 As usual, docker-compose also allows for those services to be started independently of each other if preferred.
+
+### Automatically rebuilding tokens on source file changes
+
+Run the following command to automatically rebuild the tokens in all output formats during development when changing one of the json source files:
+
+```sh
+docker-compose run --rm node lerna run watch --stream
+```
+
+This way you don't have to manually run the `build:tokens` command for every token change.

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -4876,6 +4876,12 @@
 			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
 			"dev": true
 		},
+		"merge": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+			"dev": true
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6940,6 +6946,27 @@
 			"dev": true,
 			"requires": {
 				"makeerror": "1.0.x"
+			}
+		},
+		"watch": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+			"integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"exec-sh": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+					"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+					"dev": true,
+					"requires": {
+						"merge": "^1.2.0"
+					}
+				}
 			}
 		},
 		"webidl-conversions": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -21,6 +21,7 @@
     "prepublish": "npm run build",
     "build": "npm run clean && npm run build:tokens",
     "build:tokens": "style-dictionary build -c ./.style-dictionary/config.js",
+    "watch": "watch 'npm run build:tokens' ./properties",
     "clean": "rm -rf ./dist",
     "fix": "npm run test:lint -- --fix"
   },
@@ -36,6 +37,7 @@
     "npm-run-all": "^4.1.5",
     "string.prototype.matchall": "^4.0.2",
     "style-dictionary": "^2.10.0",
+    "watch": "^1.0.2",
     "wikimedia-ui-base": "^0.15.0"
   }
 }


### PR DESCRIPTION
Run `docker-compose run --rm node lerna run watch --stream` during development to see the effect of changes to the token source files (almost) immediately in both the vue-components and the docs storybook without having to manually run `build:tokens`.