### PR TITLE
vue-components: Pass test status to Saucelabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![github](https://github.com/wmde/wikit/workflows/Build%20and%20Deploy%20documentation/badge.svg)](https://wmde.github.io/wikit/)
 [![github](https://github.com/wmde/wikit/workflows/Test%20and%20deploy/badge.svg)](https://www.chromatic.com/builds?appId=5efdb3b5f65950002286285d)
 
+[![Sauce Test Status](https://app.saucelabs.com/buildstatus/tonina)](https://app.saucelabs.com/u/tonina)
+
+[![Sauce Test Status](https://app.saucelabs.com/browser-matrix/tonina.svg)](https://app.saucelabs.com/u/tonina)
+
 The Wikibase Design System and home of WMDE-supported component implementations.
 
 ## Development

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -18,9 +18,11 @@ module.exports = {
 		// https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-e2e-nightwatch/nightwatch.config.js
 		default: {
 			launch_url: process.env.STORYBOOK_URL,
+			isLocal: true,
 		},
 		docker: {
 			launch_url: `http://storybook-vue:${process.env.VUECOMPONENTS_STORYBOOK_PORT}`,
+			isLocal: true,
 			selenium_host: 'selenium',
 			desiredCapabilities: {
 				browserName: 'chrome',
@@ -32,6 +34,7 @@ module.exports = {
 		},
 		sauceLabs: {
 			launch_url: `https://${process.env.BRANCH_NAME}--5efdb3b5f65950002286285d.chromatic.com`,
+			isLocal: false,
 			selenium_host: 'ondemand.saucelabs.com',
 			selenium_port: 80,
 			username: process.env.SAUCE_USERNAME,

--- a/vue-components/tests/e2e/globals.js
+++ b/vue-components/tests/e2e/globals.js
@@ -1,11 +1,5 @@
-// /////////////////////////////////////////////////////////////////////////////////
-// Refer to the entire list of global config settings here:
-// https://github.com/nightwatchjs/nightwatch/blob/master/lib/settings/defaults.js#L16
-//
-// More info on test globals:
-//   https://nightwatchjs.org/gettingstarted/configuration/#test-globals
-//
-// /////////////////////////////////////////////////////////////////////////////////
+const SauceLabs = require( 'saucelabs' ).default;
+const account = new SauceLabs( { user: process.env.SAUCE_USERNAME, key: process.env.SAUCE_ACCESS_KEY } );
 
 module.exports = {
 	// this controls whether to abort the test execution when an assertion failed and skip the rest
@@ -20,85 +14,22 @@ module.exports = {
 	// expect assertions
 	waitForConditionTimeout: 20000,
 
-	'default': {
-		/*
-    The globals defined here are available everywhere in any test env
-    */
-
-		/*
-    myGlobal: function() {
-      return 'I\'m a method';
-    }
-    */
+	// Pass information about the browser tests to SauceLabs
+	afterEach( client, done ) {
+		if ( !this.isLocal ) {
+			const sessionId = client.sessionId;
+			const testPassed = client.currentTest.results.failed === 0;
+			client.end( function () {
+				account.updateJob(
+					process.env.SAUCE_USERNAME,
+					sessionId,
+					{
+						tags: [ 'WiKit' ],
+						passed: testPassed,
+					},
+				);
+				done();
+			} );
+		}
 	},
-
-	'firefox': {
-		/*
-    The globals defined here are available only when the chrome testing env is being used
-       i.e. when running with --env firefox
-    */
-		/*
-     * myGlobal: function() {
-     *   return 'Firefox specific global';
-     * }
-     */
-	},
-
-	// ///////////////////////////////////////////////////////////////
-	// Global hooks
-	// - simple functions which are executed as part of the test run
-	// - take a callback argument which can be called when an async
-	//    async operation is finished
-	// ///////////////////////////////////////////////////////////////
-	/**
-	 * executed before the test run has started, so before a session is created
-	 */
-	/*
-  before(cb) {
-    //console.log('global before')
-    cb();
-  },
-  */
-
-	/**
-	 * executed before every test suite has started
-	 */
-	/*
-  beforeEach(browser, cb) {
-    //console.log('global beforeEach')
-    cb();
-  },
-  */
-
-	/**
-	 * executed after every test suite has ended
-	 */
-	/*
-  afterEach(browser, cb) {
-    browser.perform(function() {
-      //console.log('global afterEach')
-      cb();
-    });
-  },
-  */
-
-	/**
-	 * executed after the test run has finished
-	 */
-	/*
-  after(cb) {
-    //console.log('global after')
-    cb();
-  },
-  */
-
-	// ///////////////////////////////////////////////////////////////
-	// Global reporter
-	//  - define your own custom reporter
-	// ///////////////////////////////////////////////////////////////
-	/*
-  reporter(results, cb) {
-    cb();
-  }
-   */
 };

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -1,10 +1,9 @@
 module.exports = {
-	'default e2e tests': ( client ) => {
+	'Button is visible': ( client ) => {
 		client
 			.init()
 			.openComponentStory( 'button' )
 			.waitForElementVisible( '.wikit-Button' )
-			.assert.elementPresent( '.wikit-Button' )
-			.end();
+			.assert.elementPresent( '.wikit-Button' );
 	},
 };


### PR DESCRIPTION
### Make Saucelabs recognize passed or failed tests [T260260](https://phabricator.wikimedia.org/T260260)

This PR introduces logic that sends test info to saucelabs using their API after each test run.
This also adds two badges to the README to display the status of the browser tests.