### PR TITLE
Create release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+on:
+  release:
+      types:
+      - created
+
+name: Verify and Publish tokens and vue-components
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm run test
+      - name: Publish
+        run: |
+          printf '//registry.npmjs.org/:_authToken=%s\n' '${{ secrets.NPM_AUTH_TOKEN }}' > ~/.npmrc
+          lerna publish --access public


### PR DESCRIPTION
This is the first step from [T260116](https://phabricator.wikimedia.org/T260116)
This workflow will be triggered when a new release is created on the GitHub repo.
The workflow will publish both the `vue-components` and the`tokens` packages with the same version. 