### PR TITLE
add clarification in ADR overview page

### DIFF
--- a/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
+++ b/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Decisions and ADRs
 
-Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought they usually cover topics exclusive to the dev realm, ADRs are very clearly written and structured in a standardized that generally makes them accessible to all the members of our cross-functional team.
+Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought ADRs usually cover topics exclusive to the dev realm, the clarity in which they are written and structured makes them accessible to all the members of our cross-functional team.
 
 ## WiKit dev documentation
 

--- a/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
+++ b/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Decisions and ADRs
 
-Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought ADRs usually cover topics exclusive to the dev realm, the clarity in which they are written and structured makes them accessible to all the members of our cross-functional team.
+Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought ADRs usually cover topics exclusive to the dev realm, the clarity in which they are written and structured makes their content accessible to all the members of our cross-functional team.
 
 ## WiKit dev documentation
 

--- a/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
+++ b/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Decisions and ADRs
 
-Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought ADRs usually cover topics exclusive to the dev realm, the clarity in which they are written and structured makes their content accessible to all the members of our cross-functional team.
+Crucial decisions are documented in the form of Architecture Decision Records (ADRs). Although ADRs usually cover topics exclusive to the dev realm, the clarity in which they are written and structured makes their content accessible to all the members of our cross-functional team. You can find all development and design related decisions in this folder. 
 
 ## WiKit dev documentation
 

--- a/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
+++ b/docs/src/doc/decisions-and-ADRs/01_overview.stories.mdx
@@ -4,13 +4,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Decisions and ADRs
 
-Documentation on important decisions, non-tech and tech-related in the form of ADRs.
+Crucial decisions are documented in the form of Architecture Decision Records (or ADRs). Althought they usually cover topics exclusive to the dev realm, ADRs are very clearly written and structured in a standardized that generally makes them accessible to all the members of our cross-functional team.
 
 ## WiKit dev documentation
-
-Documentation which covers topics exclusive to the dev realm.
-
-We are documenting our decisions as Architecture Decision Records. Please find them in `adr/`.
 
 There is also some additional - very tech heavy - documentation contained in subfolders of the repository, usually right next to the place where a particular problem gets solved.
 


### PR DESCRIPTION
The content in the ADR overview page now clarifies that ADRs are suitable for all audiences since they are clearly written and structured.