### PR TITLE
vue-components: Add more Storybook addons

### DIFF
--- a/vue-components/.storybook/main.js
+++ b/vue-components/.storybook/main.js
@@ -4,5 +4,6 @@ module.exports = {
 		'@storybook/addon-a11y',
 		'@storybook/addon-docs',
 		'@storybook/addon-knobs',
+		'@storybook/addon-viewport',
 	],
 };

--- a/vue-components/.storybook/main.js
+++ b/vue-components/.storybook/main.js
@@ -5,5 +5,6 @@ module.exports = {
 		'@storybook/addon-docs',
 		'@storybook/addon-knobs',
 		'@storybook/addon-viewport',
+		'@storybook/addon-backgrounds',
 	],
 };

--- a/vue-components/.storybook/preview.ts
+++ b/vue-components/.storybook/preview.ts
@@ -1,7 +1,15 @@
 import { addDecorator } from '@storybook/vue';
 import { withA11y } from '@storybook/addon-a11y';
 import { withKnobs } from '@storybook/addon-knobs';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
 
 addDecorator( withA11y );
 
 addDecorator( withKnobs );
+
+export const parameters = {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+    },
+  };

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -2752,6 +2752,222 @@
 				}
 			}
 		},
+		"@storybook/addon-viewport": {
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.0.16.tgz",
+			"integrity": "sha512-3vk6lBZrKJrK9rwxglLT1p579WkLvoJxgW5ddpvSsu31NPAKfDufkDqOZOQGyMmcgIFzZJEc9eKjoTcLiHxppw==",
+			"dev": true,
+			"requires": {
+				"@storybook/addons": "6.0.16",
+				"@storybook/api": "6.0.16",
+				"@storybook/client-logger": "6.0.16",
+				"@storybook/components": "6.0.16",
+				"@storybook/core-events": "6.0.16",
+				"@storybook/theming": "6.0.16",
+				"core-js": "^3.0.1",
+				"global": "^4.3.2",
+				"memoizerific": "^1.11.3",
+				"prop-types": "^15.7.2",
+				"regenerator-runtime": "^0.13.3"
+			},
+			"dependencies": {
+				"@storybook/addons": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.16.tgz",
+					"integrity": "sha512-jGMaOJYTM2yZeX1tI6whEn+4xpI1aAybZBrc+OD21CcGoQrbF/jplZMq7xKI0Y6vOMguuTGulpUNCezD3LbBjA==",
+					"dev": true,
+					"requires": {
+						"@storybook/api": "6.0.16",
+						"@storybook/channels": "6.0.16",
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/core-events": "6.0.16",
+						"@storybook/router": "6.0.16",
+						"@storybook/theming": "6.0.16",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"regenerator-runtime": "^0.13.3"
+					}
+				},
+				"@storybook/api": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.0.16.tgz",
+					"integrity": "sha512-RTC4BKmH5i8bJUQejOHEtjebVKtOaHkmEagI2HQRalsokBc1GLAf84EGrO2TaZiRrItAPL5zZQgEnKUblsGJGw==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.3.3",
+						"@storybook/channels": "6.0.16",
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/core-events": "6.0.16",
+						"@storybook/csf": "0.0.1",
+						"@storybook/router": "6.0.16",
+						"@storybook/semver": "^7.3.2",
+						"@storybook/theming": "6.0.16",
+						"@types/reach__router": "^1.3.5",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^3.1.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3",
+						"react": "^16.8.3",
+						"regenerator-runtime": "^0.13.3",
+						"store2": "^2.7.1",
+						"telejson": "^5.0.2",
+						"ts-dedent": "^1.1.1",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/channels": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.0.16.tgz",
+					"integrity": "sha512-TsI4GA7lKD4L2w6IjODMRfnEOkmvEp4eJDgf3MKm7+sMbxwi1y1d6yrW1UQbnmwoNJWk60ArMN2yqDBV+5MNJQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1",
+						"ts-dedent": "^1.1.1",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/client-logger": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.0.16.tgz",
+					"integrity": "sha512-xM61Aewxqoo8500UxV7iPpfqwikITojiCX3+w8ZiCJ2NizSaXkis95TEFAeHqyozfNym5CqG+6v2NWvGYV3ncQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1",
+						"global": "^4.3.2"
+					}
+				},
+				"@storybook/components": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.0.16.tgz",
+					"integrity": "sha512-zpYGt3tWiN0yT7V0VhBl2T5Mr0COiNnTQUGCpA9Gl3pUBmAov2jCVf1sUxsIcBcMMZmDRcfo6NbJ/LqCFeUg+Q==",
+					"dev": true,
+					"requires": {
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/csf": "0.0.1",
+						"@storybook/theming": "6.0.16",
+						"@types/overlayscrollbars": "^1.9.0",
+						"@types/react-color": "^3.0.1",
+						"@types/react-syntax-highlighter": "11.0.4",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^3.1.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"markdown-to-jsx": "^6.11.4",
+						"memoizerific": "^1.11.3",
+						"overlayscrollbars": "^1.10.2",
+						"polished": "^3.4.4",
+						"popper.js": "^1.14.7",
+						"react": "^16.8.3",
+						"react-color": "^2.17.0",
+						"react-dom": "^16.8.3",
+						"react-popper-tooltip": "^2.11.0",
+						"react-syntax-highlighter": "^12.2.1",
+						"react-textarea-autosize": "^8.1.1",
+						"ts-dedent": "^1.1.1"
+					}
+				},
+				"@storybook/core-events": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.0.16.tgz",
+					"integrity": "sha512-ib+58N4OY8AOix2qcBH9ICRmVHUocpGaGRVlIo79WxJrpnB/HNQ8pEaniD+OAavDRq1B7uJqFlMkTXCC0GoFiQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/router": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.0.16.tgz",
+					"integrity": "sha512-zijPJ3CR4ytHE0v+pGdaWT3H+es+mLHRkR6hkqcD0ABT5HVfwMlmXJ9FkQGCVpnnNeBOz7+QKCdE13HMelQpqg==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.3.3",
+						"@types/reach__router": "^1.3.5",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0"
+					}
+				},
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				},
+				"@storybook/theming": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.16.tgz",
+					"integrity": "sha512-6D7oMEbeABYZdDY8e3i+O39XLrk6fvG3GBaSGp31BE30d269NcPkGPxMKY/nzc6MY30a+/LbBbM7b6gRKe6b4Q==",
+					"dev": true,
+					"requires": {
+						"@emotion/core": "^10.0.20",
+						"@emotion/is-prop-valid": "^0.8.6",
+						"@emotion/styled": "^10.0.17",
+						"@storybook/client-logger": "6.0.16",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.19",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.4.4",
+						"resolve-from": "^5.0.0",
+						"ts-dedent": "^1.1.1"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.9.4",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"@storybook/addons": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.4.tgz",
@@ -17045,7 +17261,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0"
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
 					}
 				},
 				"normalize-path": {
@@ -19203,6 +19420,13 @@
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
 			}
+		},
+		"nan": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -26789,7 +27013,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0"
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {
@@ -27089,7 +27314,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0"
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -2354,6 +2354,221 @@
 				"util-deprecate": "^1.0.2"
 			}
 		},
+		"@storybook/addon-backgrounds": {
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.0.16.tgz",
+			"integrity": "sha512-0sH7hlZh4bHt6zV6QyG3ryNGJsxD42iXVwWdwAShzfWJKGfLy5XwdvHUKkMEBbY9bOPeoI9oMli2RAfsD6juLQ==",
+			"dev": true,
+			"requires": {
+				"@storybook/addons": "6.0.16",
+				"@storybook/api": "6.0.16",
+				"@storybook/client-logger": "6.0.16",
+				"@storybook/components": "6.0.16",
+				"@storybook/core-events": "6.0.16",
+				"@storybook/theming": "6.0.16",
+				"core-js": "^3.0.1",
+				"memoizerific": "^1.11.3",
+				"react": "^16.8.3",
+				"regenerator-runtime": "^0.13.3"
+			},
+			"dependencies": {
+				"@storybook/addons": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.16.tgz",
+					"integrity": "sha512-jGMaOJYTM2yZeX1tI6whEn+4xpI1aAybZBrc+OD21CcGoQrbF/jplZMq7xKI0Y6vOMguuTGulpUNCezD3LbBjA==",
+					"dev": true,
+					"requires": {
+						"@storybook/api": "6.0.16",
+						"@storybook/channels": "6.0.16",
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/core-events": "6.0.16",
+						"@storybook/router": "6.0.16",
+						"@storybook/theming": "6.0.16",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"regenerator-runtime": "^0.13.3"
+					}
+				},
+				"@storybook/api": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.0.16.tgz",
+					"integrity": "sha512-RTC4BKmH5i8bJUQejOHEtjebVKtOaHkmEagI2HQRalsokBc1GLAf84EGrO2TaZiRrItAPL5zZQgEnKUblsGJGw==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.3.3",
+						"@storybook/channels": "6.0.16",
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/core-events": "6.0.16",
+						"@storybook/csf": "0.0.1",
+						"@storybook/router": "6.0.16",
+						"@storybook/semver": "^7.3.2",
+						"@storybook/theming": "6.0.16",
+						"@types/reach__router": "^1.3.5",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^3.1.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3",
+						"react": "^16.8.3",
+						"regenerator-runtime": "^0.13.3",
+						"store2": "^2.7.1",
+						"telejson": "^5.0.2",
+						"ts-dedent": "^1.1.1",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/channels": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.0.16.tgz",
+					"integrity": "sha512-TsI4GA7lKD4L2w6IjODMRfnEOkmvEp4eJDgf3MKm7+sMbxwi1y1d6yrW1UQbnmwoNJWk60ArMN2yqDBV+5MNJQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1",
+						"ts-dedent": "^1.1.1",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/client-logger": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.0.16.tgz",
+					"integrity": "sha512-xM61Aewxqoo8500UxV7iPpfqwikITojiCX3+w8ZiCJ2NizSaXkis95TEFAeHqyozfNym5CqG+6v2NWvGYV3ncQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1",
+						"global": "^4.3.2"
+					}
+				},
+				"@storybook/components": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.0.16.tgz",
+					"integrity": "sha512-zpYGt3tWiN0yT7V0VhBl2T5Mr0COiNnTQUGCpA9Gl3pUBmAov2jCVf1sUxsIcBcMMZmDRcfo6NbJ/LqCFeUg+Q==",
+					"dev": true,
+					"requires": {
+						"@storybook/client-logger": "6.0.16",
+						"@storybook/csf": "0.0.1",
+						"@storybook/theming": "6.0.16",
+						"@types/overlayscrollbars": "^1.9.0",
+						"@types/react-color": "^3.0.1",
+						"@types/react-syntax-highlighter": "11.0.4",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^3.1.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"markdown-to-jsx": "^6.11.4",
+						"memoizerific": "^1.11.3",
+						"overlayscrollbars": "^1.10.2",
+						"polished": "^3.4.4",
+						"popper.js": "^1.14.7",
+						"react": "^16.8.3",
+						"react-color": "^2.17.0",
+						"react-dom": "^16.8.3",
+						"react-popper-tooltip": "^2.11.0",
+						"react-syntax-highlighter": "^12.2.1",
+						"react-textarea-autosize": "^8.1.1",
+						"ts-dedent": "^1.1.1"
+					}
+				},
+				"@storybook/core-events": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.0.16.tgz",
+					"integrity": "sha512-ib+58N4OY8AOix2qcBH9ICRmVHUocpGaGRVlIo79WxJrpnB/HNQ8pEaniD+OAavDRq1B7uJqFlMkTXCC0GoFiQ==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/router": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.0.16.tgz",
+					"integrity": "sha512-zijPJ3CR4ytHE0v+pGdaWT3H+es+mLHRkR6hkqcD0ABT5HVfwMlmXJ9FkQGCVpnnNeBOz7+QKCdE13HMelQpqg==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.3.3",
+						"@types/reach__router": "^1.3.5",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0"
+					}
+				},
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				},
+				"@storybook/theming": {
+					"version": "6.0.16",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.16.tgz",
+					"integrity": "sha512-6D7oMEbeABYZdDY8e3i+O39XLrk6fvG3GBaSGp31BE30d269NcPkGPxMKY/nzc6MY30a+/LbBbM7b6gRKe6b4Q==",
+					"dev": true,
+					"requires": {
+						"@emotion/core": "^10.0.20",
+						"@emotion/is-prop-valid": "^0.8.6",
+						"@emotion/styled": "^10.0.17",
+						"@storybook/client-logger": "6.0.16",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.19",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.4.4",
+						"resolve-from": "^5.0.0",
+						"ts-dedent": "^1.1.1"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.9.4",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"@storybook/addon-docs": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.0.4.tgz",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -40,6 +40,7 @@
     "@storybook/addon-a11y": "^6.0.4",
     "@storybook/addon-docs": "^6.0.4",
     "@storybook/addon-knobs": "^6.0.4",
+    "@storybook/addon-viewport": "^6.0.16",
     "@storybook/vue": "^6.0.4",
     "@types/jest": "^24.0.19",
     "@typescript-eslint/eslint-plugin": "^2.33.0",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.0.4",
+    "@storybook/addon-backgrounds": "^6.0.16",
     "@storybook/addon-docs": "^6.0.4",
     "@storybook/addon-knobs": "^6.0.4",
     "@storybook/addon-viewport": "^6.0.16",


### PR DESCRIPTION
`@storybook/addon-viewports` allows you to look at stories in different viewports. Said viewports are customizable. I used the ones that come from the addon itself.
![Screenshot_2020-08-23 Button - Normal ⋅ Storybook](https://user-images.githubusercontent.com/24877689/90981682-c43b5580-e562-11ea-9507-5f85da459e10.png)

`@storybook/addon-backgrounds` allows you to look at stories in different backgrounds. Said backgrounds are customizable. The default ones are just light and dark.
![Screenshot_2020-08-23 Button - Normal ⋅ Storybook(1)](https://user-images.githubusercontent.com/24877689/90981684-c7364600-e562-11ea-9e53-b264a72683b1.png)
