### PR TITLE
tokens: Execute build script on prepare, not postinstall

### DIFF
--- a/tokens/package.json
+++ b/tokens/package.json
@@ -17,11 +17,10 @@
     "access": "public"
   },
   "scripts": {
-    "postinstall": "node build/wikimedia-ui-base",
     "test": "npm-run-all test:*",
     "test:lint": "eslint --ext .json,.js .",
     "test:unit": "jest .",
-    "prepublish": "npm run build",
+    "prepublish": "node build/wikimedia-ui-base && npm run build",
     "build": "npm run clean && npm run build:tokens",
     "build:tokens": "style-dictionary build -c ./.style-dictionary/config.js",
     "watch": "watch 'npm run build:tokens' ./properties",


### PR DESCRIPTION
Bug: [T261078](https://phabricator.wikimedia.org/T261078)

Currently both  `npm i @wmde/wikit-vue-components` and `npm i @wmde/wikit-tokens` fail with
```
> @wmde/wikit-tokens@1.0.0 postinstall ../node_modules/@wmde/wikit-tokens
> node build/wikimedia-ui-base

internal/modules/cjs/loader.js:651
    throw err;
    ^

Error: Cannot find module '../node_modules/@wmde/wikit-tokens/build/wikimedia-ui-base'
```

Apparently the build script needs to be executed on `prepare`, rather than on `postinstall`.
I tested the `prepare` script with `npm pack` and then installing it in a test vue repo.