### PR TITLE
Add sauceSafari to e2e script

### DIFF
--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -85,8 +85,8 @@ module.exports = {
 			extends: 'sauceLabs',
 			desiredCapabilities: {
 				browserName: 'safari',
-				browserVersion: 'latest',
-				platformName: 'macOS 10.14',
+				platform: 'macOS 10.15',
+				version: 'latest',
 			},
 		},
 	},

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -13,7 +13,7 @@
     "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
     "test:unit": "vue-cli-service test:unit",
     "e2e": "vue-cli-service test:e2e",
-    "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge",
+    "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge,sauceSafari",
     "build:extract-stories": "npx sb@6.0.0-rc.24 extract storybook-static storybook-static/stories.json",
     "build:storybook": "build-storybook",
     "fix": "vue-cli-service lint",

--- a/vue-components/tests/e2e/custom-commands/openComponentStory.js
+++ b/vue-components/tests/e2e/custom-commands/openComponentStory.js
@@ -1,5 +1,5 @@
 module.exports.command = function openComponentStory( component ) {
-	return this.waitForElementVisible( '#root' )
+	return this.waitForElementPresent( '#root' )
 		.click( `a[href="#${component}"]` )
 		.element(
 			'id',

--- a/vue-components/tests/e2e/globals.js
+++ b/vue-components/tests/e2e/globals.js
@@ -14,6 +14,9 @@ module.exports = {
 	// expect assertions
 	waitForConditionTimeout: 20000,
 
+	connectionRetryTimeout: 90000,
+	connectionRetryCount: 3,
+
 	// Pass information about the browser tests to SauceLabs
 	afterEach( client, done ) {
 		if ( !this.isLocal ) {

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -3,7 +3,7 @@ module.exports = {
 		client
 			.init()
 			.openComponentStory( 'button' )
-			.waitForElementVisible( '.wikit-Button' )
-			.assert.elementPresent( '.wikit-Button' );
+			.waitForElementPresent( '.wikit-Button' )
+			.assert.visible( '.wikit-Button' );
 	},
 };

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -4,6 +4,6 @@ module.exports = {
 			.init()
 			.openComponentStory( 'button' )
 			.waitForElementPresent( '.wikit-Button' )
-			.assert.not.cssProperty( '.wikit-Button', 'display', 'none' );
+			.assert.elementPresent( '.wikit-Button' );
 	},
 };

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -4,6 +4,6 @@ module.exports = {
 			.init()
 			.openComponentStory( 'button' )
 			.waitForElementPresent( '.wikit-Button' )
-			.assert.visible( '.wikit-Button' );
+			.assert.not.cssProperty( '.wikit-Button', 'display', 'none' );
 	},
 };

--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -4,6 +4,6 @@ module.exports = {
 			.init()
 			.openComponentStory( 'button' )
 			.waitForElementPresent( '.wikit-Button' )
-			.assert.elementPresent( '.wikit-Button' );
+			.assert.visible( '.wikit-Button' );
 	},
 };


### PR DESCRIPTION
We configured the browser tests (on Saucelabs) to run on Safari but that never happened because the npm command was not executing the sauceSafari configuration.

This PR fixes that and attempts to work around a [bug in nightwatch (#2308)](https://github.com/nightwatchjs/nightwatch/issues/2308) involving `waitForElementVisible` in Safari.