### PR TITLE
Use commit hash as chromatic url

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -32,7 +32,7 @@ jobs:
       run: npm run chromatic
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^A-Za-Z0-9_]/-/g')"
       id: extract_branch
     - name: Run e2e cross browser tests
       env:

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -32,11 +32,11 @@ jobs:
       run: npm run chromatic
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^A-Za-Z0-9_]/-/g')"
+      run: echo "##[set-output name=branch;]$(echo \"${GITHUB_REF#refs/heads/}\" | md5sum"
       id: extract_branch
     - name: Run e2e cross browser tests
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+        BRANCH_HASH: ${{ steps.extract_branch.outputs.branch }}
       run: npm run test:e2e

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -30,13 +30,13 @@ jobs:
       run: npm run build:storybook
     - name: Deploy Storybook
       run: npm run chromatic
-    - name: Extract branch name
+    - name: Extract commmit hash
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo \"${GITHUB_REF#refs/heads/}\" | md5sum"
-      id: extract_branch
+      run: echo "##[set-output name=commit;]$(git rev-parse --short ${GITHUB_SHA})"
+      id: extract_commit
     - name: Run e2e cross browser tests
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        BRANCH_HASH: ${{ steps.extract_branch.outputs.branch }}
+        COMMIT_HASH: ${{ steps.extract_commit.outputs.commit }}
       run: npm run test:e2e

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -30,7 +30,7 @@ jobs:
       run: npm run build:storybook
     - name: Deploy Storybook
       run: npm run chromatic
-    - name: Extract commmit hash
+    - name: Extract commit hash
       shell: bash
       run: echo "##[set-output name=commit;]$(git rev-parse --short ${GITHUB_SHA})"
       id: extract_commit

--- a/docs/src/00-doc/02_contributing.stories.mdx
+++ b/docs/src/00-doc/02_contributing.stories.mdx
@@ -11,14 +11,6 @@ WiKit was designed in mind with enabling different roles (dev, UX, PM etc.) to c
 WiKit lives on GitHub. Anyone within the wmde GitHub org should be able to contribute to the repository.
 If you don't have write access, please reach out to a manager.
 
-### Branches
-
-Name your branches using lowercase letters `[a-z]` and `-` or `_`, e.g. `improve-overview-doc`, `improve_overview_doc`.  
-This is important, because the vue storybook is built and deployed to [Chromatic](https://www.chromatic.com/builds?appId=5efdb3b5f65950002286285d&branch=master) using the branch name.  
-For example, if your branch is called `dropdown_component`, the vue storybook built on that branch will be deployed to  
-https://dropdown_component--5efdb3b5f65950002286285d.chromatic.com  
-This link is used by the cross-browser tests running on Saucelabs. If your branch name contains a character that is automatically changed by the browser (e.g. uppercase letters become lowercase letters), the tests will fail, because they won't be able to open the Chromatic link.
-
 ### Checks
 
 All checks configured to run on each branch need to pass in order for the PR to be merged (the merge button will be inactive).

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -33,7 +33,7 @@ module.exports = {
 			},
 		},
 		sauceLabs: {
-			launch_url: `https://${process.env.BRANCH_NAME}--5efdb3b5f65950002286285d.chromatic.com`,
+			launch_url: `https://${process.env.BRANCH_HASH}--5efdb3b5f65950002286285d.chromatic.com`,
 			isLocal: false,
 			selenium_host: 'ondemand.saucelabs.com',
 			selenium_port: 80,

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -33,7 +33,7 @@ module.exports = {
 			},
 		},
 		sauceLabs: {
-			launch_url: `https://${process.env.BRANCH_HASH}--5efdb3b5f65950002286285d.chromatic.com`,
+			launch_url: `https://${process.env.COMMIT_HASH}--5efdb3b5f65950002286285d.chromatic.com`,
 			isLocal: false,
 			selenium_host: 'ondemand.saucelabs.com',
 			selenium_port: 80,


### PR DESCRIPTION
Extract and use the commit hash as the [chromatic permalink](https://www.chromatic.com/docs/permalinks#build-your-own-permalink) for saucelabs to access. This prevents issues with branch names and enables us to name our branches in any way we please.

Related To: [T262270](https://phabricator.wikimedia.org/T262270)