### PR TITLE
docker-compose: rm redundant build file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     node:
         build:
             context: ./
-            dockerfile: ./Dockerfile
         image: wmde/wikit
         volumes:
             - '~/.npm:/.npm'


### PR DESCRIPTION
It was rightfully pointed out that there is no need to specify the build
file if it equals default Dockerfile.