### PR TITLE
vue-components: add Icon component

### DIFF
--- a/tokens/properties/components/Icon.json
+++ b/tokens/properties/components/Icon.json
@@ -1,0 +1,20 @@
+{
+	"wikit-Icon": {
+		"color": {
+			"value": "{icon.color.base.value}"
+		},
+		"error-color": {
+			"value": "{icon.color.error.value}"
+		},
+		"warning-color": {
+			"value": "{icon.color.warning.value}"
+		},
+		"medium-size": {
+			"value": "{icon.size.medium.value}",
+			"comment": "icons are squares, so height and width are identical"
+		},
+		"large-size": {
+			"value": "{icon.size.large.value}"
+		}
+	}
+}

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^6.2.2",
     "geckodriver": "^1.19.1",
+    "jest-serializer-vue": "^2.0.2",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.32",
     "postcss-dir-pseudo-class": "^5.0.0",

--- a/vue-components/src/components/Icon.vue
+++ b/vue-components/src/components/Icon.vue
@@ -1,0 +1,105 @@
+<template>
+	<!-- eslint-disable max-len -->
+	<span :class="['wikit', 'wikit-Icon', `wikit-Icon--${size}`, `wikit-Icon--${color}`]">
+		<!-- error icon -->
+		<svg
+			class="wikit-Icon__svg"
+			viewBox="0 0 16 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			v-if="type === 'error'"
+		>
+			<path
+				fill="currentColor"
+				d="M11.4939 0H4.50612L0 4.50612V11.5102L4.50612 16H11.5102L16 11.4939V4.50612L11.4939 0Z
+					M8.8 11.9938H7.2V10.3999H8.8V11.9938Z
+					M8.8 9.6H7.2V4H8.8V9.6Z"
+			/>
+		</svg>
+
+		<!-- warning icon -->
+		<svg
+			class="wikit-Icon__svg"
+			viewBox="0 0 16 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			v-else-if="type === 'alert'"
+		>
+			<path fill="currentColor" d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z" />
+		</svg>
+	</span>
+	<!-- eslint-disable max-len -->
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { iconTypes, iconColors, iconSizes } from './iconProps';
+
+/**
+ * Every SVG icon that is added to this component needs to have at least one element (e.g. a `<path>`) with
+ * `fill="currentColor"` for the part of the icon that is intended to be colored by the `color` prop.
+ *
+ * More info on `fill="currentColor"`:
+ * https://css-tricks.com/cascading-svg-fill-color/
+ *
+ */
+export default Vue.extend( {
+	name: 'Icon',
+
+	props: {
+		type: {
+			type: String,
+			validator( value: string ): boolean {
+				return iconTypes.includes( value );
+			},
+			required: true,
+		},
+
+		color: {
+			type: String,
+			validator( value: string ): boolean {
+				return iconColors.includes( value );
+			},
+			default: 'base',
+		},
+
+		size: {
+			type: String,
+			validator( value: string ): boolean {
+				return iconSizes.includes( value );
+			},
+			default: 'large',
+		},
+	},
+} );
+</script>
+
+<style lang="scss">
+.wikit-Icon {
+	display: inline-flex;
+	vertical-align: middle;
+	align-items: center;
+
+	&--base {
+		color: $wikit-Icon-color;
+	}
+
+	&--error {
+		color: $wikit-Icon-error-color;
+	}
+
+	&--warning {
+		color: $wikit-Icon-warning-color;
+	}
+
+	&--large &__svg {
+		width: $wikit-Icon-large-size;
+		height: $wikit-Icon-large-size;
+	}
+
+	&--medium &__svg {
+		width: $wikit-Icon-medium-size;
+		height: $wikit-Icon-medium-size;
+	}
+}
+</style>

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -1,0 +1,5 @@
+export const iconTypes = [ 'alert', 'error' ];
+
+export const iconColors = [ 'base', 'warning', 'error' ];
+
+export const iconSizes = [ 'medium', 'large' ];

--- a/vue-components/stories/Icon.stories.ts
+++ b/vue-components/stories/Icon.stories.ts
@@ -1,0 +1,25 @@
+import Icon from '@/components/Icon';
+import { iconSizes, iconColors, iconTypes } from '@/components/iconProps';
+import { Component } from 'vue';
+
+export default {
+	component: Icon,
+	title: 'Icon',
+};
+
+export function all(): Component {
+	return {
+		data(): object {
+			return { iconTypes };
+		},
+		components: { Icon },
+		template: `
+			<div>
+				<div v-for="type in iconTypes" style="float: left; padding: 20px 50px; color: #555">
+					<Icon :type="type" />
+					{{ type }}
+				</div>
+			</div>
+		`,
+	};
+}

--- a/vue-components/tests/unit/components/Icon.spec.ts
+++ b/vue-components/tests/unit/components/Icon.spec.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import Icon from '@/components/Icon.vue';
+import { iconSizes, iconColors, iconTypes } from '@/components/iconProps';
+
+describe( 'Icon', () => {
+
+	it( 'renders an error icon given type "error"', () => {
+		const wrapper = mount( Icon, {
+			propsData: {
+				type: 'error',
+			},
+		} );
+
+		expect( wrapper.element ).toMatchSnapshot();
+	} );
+
+	it( 'renders an alert icon given type "alert"', () => {
+		const wrapper = mount( Icon, {
+			propsData: {
+				type: 'alert',
+			},
+		} );
+
+		expect( wrapper.element ).toMatchSnapshot();
+	} );
+
+	it( 'validates the type prop', () => {
+		expect( () => mount( Icon, {
+			propsData: {
+				type: 'potato',
+			},
+		} ) ).toThrow();
+	} );
+
+	it( 'validates the color prop', () => {
+		expect( () => mount( Icon, {
+			propsData: {
+				type: 'error',
+				color: 'potato',
+			},
+		} ) ).toThrow();
+	} );
+
+	it( 'validates the size prop', () => {
+		expect( () => mount( Icon, {
+			propsData: {
+				type: 'error',
+				size: 'potato',
+			},
+		} ) ).toThrow();
+	} );
+
+	it.each( iconTypes )( '%s: has at least one part of the SVG element that can be colored', ( iconType ) => {
+		const wrapper = mount( Icon, {
+			propsData: {
+				type: iconType,
+			},
+		} );
+
+		expect( wrapper.find( '[fill="currentColor"]' ).exists() ).toBeTruthy();
+	} );
+
+	it.each( iconColors )( 'renders the color "%s" as a root node class', ( color ) => {
+		expect( mount( Icon, {
+			propsData: {
+				type: 'alert',
+				color,
+			},
+		} ).classes() ).toContain( `wikit-Icon--${color}` );
+	} );
+
+	it.each( iconSizes )( 'renders the size "%s" as a root node class', ( size ) => {
+		expect( mount( Icon, {
+			propsData: {
+				type: 'alert',
+				size,
+			},
+		} ).classes() ).toContain( `wikit-Icon--${size}` );
+	} );
+
+} );

--- a/vue-components/tests/unit/components/__snapshots__/Icon.spec.ts.snap
+++ b/vue-components/tests/unit/components/__snapshots__/Icon.spec.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Icon renders an alert icon given type "alert" 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <svg
+    class="wikit-Icon__svg"
+    fill="none"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z"
+      fill="currentColor"
+    />
+  </svg>
+</span>
+`;
+
+exports[`Icon renders an error icon given type "error" 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <svg
+    class="wikit-Icon__svg"
+    fill="none"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M11.4939 0H4.50612L0 4.50612V11.5102L4.50612 16H11.5102L16 11.4939V4.50612L11.4939 0Z
+				M8.8 11.9938H7.2V10.3999H8.8V11.9938Z
+				M8.8 9.6H7.2V4H8.8V9.6Z"
+      fill="currentColor"
+    />
+  </svg>
+</span>
+`;


### PR DESCRIPTION
# Icon Component (internal for now)
Split out of #193 to ease review.

This intentionally only includes 2 icons in 3 colors and 2 sizes, because those were the ones that are needed for the TextInput component. The rest of the component is going to be implemented at a later point in time.

Figma spec: https://www.figma.com/file/gi3JYwSUQYhKS0mHwK25cQwi/WiKit?node-id=2510%3A4053