### PR TITLE
correct and update design doc

### DIFF
--- a/docs/src/00-doc/03-create-reusable-components/02_designing_components.stories.mdx
+++ b/docs/src/00-doc/03-create-reusable-components/02_designing_components.stories.mdx
@@ -199,7 +199,7 @@ Although unlikely, it may happen that the newly needed alias token does not yet 
 
 Figma is the agreed-upon handover environment. In order to collect specs in a centralized way, designers should create a new documentation frame in the _Specs and documentation_ page, and name it after their “Component_Variant” [see example](https://www.figma.com/file/gi3JYwSUQYhKS0mHwK25cQwi/WiKit-%F0%9F%94%A5?node-id=3348%3A259)). A link to said specifications' frame should be shared in the appropriate Phabricator ticket.
 
-Many of the handover items should already be covered if the design process is followed. At this point, though, it is essential to make sure that the collected information really covers the needs of developers, and that it is expressed in a clear and distinct way. An effective handover documentation provides developers with:
+Many of the handover items should already be covered if the design process has been followed. At this point, though, it is essential to make sure that the collected information really covers the needs of developers, and that it is expressed in a clear and distinct way. An effective handover documentation provides developers with:
 
 - Component specs that are fully outlined using tokens (as defined in 1.4):<br/>
   - **Visual** specification (sizes, paddings, typographic styles, colors) are fully defined using design tokens ([See 2.2](#22-using-tokens-to-specify-a-new-component)).

--- a/docs/src/00-doc/03-create-reusable-components/02_designing_components.stories.mdx
+++ b/docs/src/00-doc/03-create-reusable-components/02_designing_components.stories.mdx
@@ -84,7 +84,7 @@ As it can be inferred from the previous sections, the design of new system compo
 
 - The design of the component and **all its interactive states** are fully represented in Figma, and all the component’s essential documentation is defined ([See 1.4](#14-document))
 
-- **Accessibility** has been taken into consideration (contrast, sizing, copy)
+- [**Accessibility** guidelines](https://design.wikimedia.org/style-guide/design-principles_accessibility.html) have been considered
 
 - **Responsive** behavior has been defined
 
@@ -199,7 +199,7 @@ Although unlikely, it may happen that the newly needed alias token does not yet 
 
 Figma is the agreed-upon handover environment. In order to collect specs in a centralized way, designers should create a new documentation frame in the _Specs and documentation_ page, and name it after their “Component_Variant” [see example](https://www.figma.com/file/gi3JYwSUQYhKS0mHwK25cQwi/WiKit-%F0%9F%94%A5?node-id=3348%3A259)). A link to said specifications' frame should be shared in the appropriate Phabricator ticket.
 
-Many of the handover items should already be covered through by the design process. At this point, though, it is essential to make sure that the collected information really covers the needs of developer, and is expressed in a clear and distinct way. An effective handover documentation provides developers with:
+Many of the handover items should already be covered if the design process is followed. At this point, though, it is essential to make sure that the collected information really covers the needs of developers, and that it is expressed in a clear and distinct way. An effective handover documentation provides developers with:
 
 - Component specs that are fully outlined using tokens (as defined in 1.4):<br/>
   - **Visual** specification (sizes, paddings, typographic styles, colors) are fully defined using design tokens ([See 2.2](#22-using-tokens-to-specify-a-new-component)).


### PR DESCRIPTION
A link to the Accessibility guidelines page in the WMF Style guide has been included in the "Design definition of done" section. Also, a small typo and some style issues have been corrected.