### PR TITLE
use phabricator as a bug tracker for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5"
+  },
+  "bugs": {
+    "url": "https://phabricator.wikimedia.org/tag/wikidata_design_system/"
   }
 }

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -28,7 +28,7 @@
     "fix": "npm run test:lint -- --fix"
   },
   "bugs": {
-    "url": "https://github.com/wmde/wikit/issues"
+    "url": "https://phabricator.wikimedia.org/tag/wikidata_design_system/"
   },
   "devDependencies": {
     "eslint": "^7.3.1",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -87,5 +87,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wmde/wikit.git"
+  },
+  "bugs": {
+    "url": "https://phabricator.wikimedia.org/tag/wikidata_design_system/"
   }
 }


### PR DESCRIPTION
The title should maybe read "for all published packages and the root
project" instead but it's cumbersome.

A short research did not yield any information if just putting it in the
root package.json would somehow have lerna take care of distributing it
to the packages but I wanted to be sure the information is part of the
published artifacts.