### PR TITLE
TextInput: fix incorrect typing

### DIFF
--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -33,9 +33,11 @@ export default Vue.extend( {
 	props: {
 		error: {
 			type: Object,
-			validator( error: object ): boolean {
+			validator( error: { type?: string; message?: string } ): boolean {
 				return error === null ||
-					[ 'warning', 'error' ].includes( error.type ) && typeof error.message === 'string';
+					typeof error.message === 'string' &&
+					typeof error.type === 'string' &&
+					[ 'warning', 'error' ].includes( error.type );
 			},
 			default: null,
 		},
@@ -69,7 +71,7 @@ export default Vue.extend( {
 			/**
 			 * contains user input, i.e. the contents of the input value
 			 */
-			this.$emit( 'input', e.target?.value );
+			this.$emit( 'input', ( e.target as HTMLInputElement ).value );
 		},
 	},
 


### PR DESCRIPTION
This caused a build error in the Query Builder code base when loading the TextInput.vue source file.

Interestingly I'm not getting any errors running `docker-compose run --rm node lerna run build --scope @wmde/wikit-vue-components` even before fixing them, but the problems are definitely there. I can't see any major differences between the two (Query Builder and vue-components/ here) build setups. I'd be curious to hear if anyone has an idea why the type checking isn't as strict here.

Phabricator: https://phabricator.wikimedia.org/T264784