### PR TITLE
Add prepare script fo vue-components

### DIFF
--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -23,7 +23,8 @@
     "test:lint": "vue-cli-service lint --no-fix",
     "test:lintcss": "stylelint '**/*.vue'",
     "test-unit-coverage": "vue-cli-service test:unit -c ./jest.config.js --coverage",
-    "chromatic": "npx chromatic build --project-token=3evi132fpys --build-script-name=build:storybook"
+    "chromatic": "npx chromatic build --project-token=3evi132fpys --build-script-name=build:storybook",
+    "prepare": "npm run build"
   },
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
This PR aims to resolve an issue with the `dist` folder being excluded from our npm package. To validate and reproduce locally, please follow these instructions: https://phabricator.wikimedia.org/T264891#6536974

Once this PR is merged, a release needs to be made to confirm the issue was indeed fixed and fix the bug this PR addresses.

Bug: [T264891](https://phabricator.wikimedia.org/T264891)