### PR TITLE
vue-components: plain storybook extract command

### DIFF
--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -7156,9 +7156,9 @@
 			}
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -10919,9 +10919,9 @@
 			}
 		},
 		"copy-webpack-plugin": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-			"integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+			"integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
 			"dev": true,
 			"requires": {
 				"cacache": "^12.0.3",
@@ -10934,7 +10934,7 @@
 				"normalize-path": "^3.0.0",
 				"p-limit": "^2.2.1",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^2.1.2",
+				"serialize-javascript": "^4.0.0",
 				"webpack-log": "^2.0.0"
 			},
 			"dependencies": {
@@ -10997,10 +10997,13 @@
 					}
 				},
 				"serialize-javascript": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-					"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-					"dev": true
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
 				},
 				"slash": {
 					"version": "1.0.0",
@@ -19719,9 +19722,9 @@
 			"dev": true
 		},
 		"node-forge": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
 			"dev": true
 		},
 		"node-int64": {
@@ -23903,12 +23906,12 @@
 			"dev": true
 		},
 		"selfsigned": {
-			"version": "1.10.7",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-			"integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+			"version": "1.10.8",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+			"integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
 			"dev": true,
 			"requires": {
-				"node-forge": "0.9.0"
+				"node-forge": "^0.10.0"
 			}
 		},
 		"semver": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -14,7 +14,7 @@
     "test:unit": "vue-cli-service test:unit",
     "e2e": "vue-cli-service test:e2e",
     "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge,sauceSafari",
-    "build:extract-stories": "npx sb@6.0.0-rc.24 extract storybook-static storybook-static/stories.json",
+    "build:extract-stories": "npx sb extract storybook-static storybook-static/stories.json",
     "build:storybook": "build-storybook",
     "fix": "vue-cli-service lint",
     "fix:css": "stylelint '**/*.vue' --fix",


### PR DESCRIPTION
At the time of writing, storybook 6 was not released yet and running the
`extract` command on a storybook 5 (the npx default) caused an error.

Not sure if pinning to the now-current storybook version would be
better, but it's not how the storybook people document it[1], and will
cause future update effort (or inconsistency) while it is unlikely the
command will ever change without us having to touch the line anyways.

[1]: https://storybook.js.org/docs/vue/workflows/storybook-composition#improve-your-storybook-composition