### PR TITLE
Fix component navigation in composed storybook

### DIFF
--- a/vue-components/.storybook/manager.ts
+++ b/vue-components/.storybook/manager.ts
@@ -1,5 +1,0 @@
-import { addons } from '@storybook/addons';
-
-addons.setConfig( {
-	showRoots: false,
-} );

--- a/vue-components/stories/Input.stories.ts
+++ b/vue-components/stories/Input.stories.ts
@@ -3,7 +3,8 @@ import { Component } from 'vue';
 
 export default {
 	component: Input,
-	title: 'Input/Basic',
+	// the `/` prefix in the title is needed for "Input" to appear as a folded navigation item, and not a headline
+	title: '/Input/Basic',
 };
 
 export function all(): Component {

--- a/vue-components/stories/TextInput.stories.ts
+++ b/vue-components/stories/TextInput.stories.ts
@@ -3,7 +3,8 @@ import { Component } from 'vue';
 
 export default {
 	component: TextInput,
-	title: 'Input/TextInput',
+	// the `/` prefix in the title is needed for "Input" to appear as a folded navigation item, and not a headline
+	title: '/Input/TextInput',
 };
 
 export function all(): Component {

--- a/vue-components/stories/ValidationMessage.stories.ts
+++ b/vue-components/stories/ValidationMessage.stories.ts
@@ -3,7 +3,8 @@ import { Component } from 'vue';
 
 export default {
 	component: ValidationMessage,
-	title: 'Message/ValidationMessage',
+	// the `/` prefix in the title is needed for "Message" to appear as a folded navigation item, and not a headline
+	title: '/Message/ValidationMessage',
 };
 
 export function all(): Component {


### PR DESCRIPTION
67c106894ec3f82763a9dd61f2816bfbb3366d91 set a configuration option for
the navigation of the vue components storybook. This option doesn't get
applied for the docs storybook which caused the components' navigation
items not to look as intended in the composed storybook.

(thanks @wiese for spotting that)

![Screenshot from 2020-10-15 11-12-52](https://user-images.githubusercontent.com/453024/96102963-6890a700-0ed7-11eb-8f98-167b7eb19226.png)
^ what it should have looked like

![Screenshot from 2020-10-15 11-12-26](https://user-images.githubusercontent.com/453024/96102959-67f81080-0ed7-11eb-8f1b-3680c491a3f9.png)
^ what it looked like in composition mode before this patch