### PR TITLE
vue-components: fix dist entry point

### DIFF
--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -26,7 +26,7 @@
     "chromatic": "npx chromatic build --project-token=3evi132fpys --build-script-name=build:storybook",
     "prepare": "npm run build"
   },
-  "main": "dist/index.js",
+  "main": "dist/wikit-vue-components.common.js",
   "files": [
     "src/",
     "dist/"


### PR DESCRIPTION
This allows consuming applications to load components via
`import { Button } from '@wmde/wikit-vue-components';` which is what our
docs already claim to work. The `main` entry that is currently there
(dist/index.js) doesn't exist.

(Sorry, I should've noticed that while reviewing #211.)

I tried this change out in the query builder repo, and it works ~~, but complains about missing type declarations, which I think can be added in a separate change~~.

Added the missing puzzle piece for enabling imports from a TS code base in #223.