### PR TITLE
vue-components: export .d.ts files

### DIFF
--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
+    "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json && tsc --emitDeclarationOnly",
     "test:unit": "vue-cli-service test:unit",
     "e2e": "vue-cli-service test:e2e",
     "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge,sauceSafari",
@@ -31,6 +31,7 @@
     "src/",
     "dist/"
   ],
+  "types": "dist/main.d.ts",
   "dependencies": {
     "@wmde/wikit-tokens": "^1.1.2",
     "core-js": "^3.6.5",

--- a/vue-components/tsconfig.json
+++ b/vue-components/tsconfig.json
@@ -10,6 +10,8 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "baseUrl": ".",
+    "declaration": true,
+    "declarationDir": "dist/",
     "types": [
       "webpack-env",
       "jest"
@@ -28,10 +30,7 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue",
-    "tests/**/*.ts",
-    "tests/**/*.tsx"
+    "src/**/*.vue"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Exporting type declaration files with the component library allows us to import its bundled `dist/wikit-vue-components.common.js` file from a TypeScript code base without producing compile-time errors. For now, the types for exported components don't contain any information beyond declaring them as Vue components, i.e. no information about props or slots.

The test files are removed from the tsconfig `include` entry to avoid exporting type declaration files for them. This shouldn't have 
 any effect when running the tests.