### PR TITLE
Input: re-emit input event to allow parents to listen for `@input`

### DIFF
--- a/vue-components/src/components/Input.vue
+++ b/vue-components/src/components/Input.vue
@@ -1,7 +1,9 @@
 <template>
+	<!-- re-emits the input event so that parent components can use `@input` instead of `@input.native` -->
 	<input
 		type="text"
 		:class="classes"
+		@input="$emit( 'input', $event.target.value )"
 	>
 </template>
 

--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -3,7 +3,7 @@
 		<div class="wikit-TextInput__label">{{ label }}</div>
 		<Input
 			:value="value"
-			@input.native="emitInputEvent"
+			@input="emitInputEvent"
 			:feedback-type="feedbackType"
 			:placeholder="placeholder"
 			:disabled="disabled"
@@ -65,11 +65,11 @@ export default Vue.extend( {
 	},
 
 	methods: {
-		emitInputEvent( e: InputEvent ): void {
+		emitInputEvent( value: string ): void {
 			/**
 			 * contains user input, i.e. the contents of the input value
 			 */
-			this.$emit( 'input', ( e.target as HTMLInputElement ).value );
+			this.$emit( 'input', value );
 		},
 	},
 


### PR DESCRIPTION
This also allows us to bind a value to the Input component via `v-model` which we tripped over while working on #219.