### PR TITLE
Add bump-version script

### DIFF
--- a/docs/src/00-doc/04_release_management.stories.mdx
+++ b/docs/src/00-doc/04_release_management.stories.mdx
@@ -27,9 +27,9 @@ It is also their responsibility to inform other relevant roles like UX and PM (i
 ## Creating a release 
 
 Once your changes are merged and you want to release a new version of the components library you need to take the following steps:
- - To release a new version run the command `lerna version [major | minor | patch | premajor | preminor | prepatch | prerelease]`. This will take care of updating the version number, committing and pushing the changes.
-[lerna version docs](https://github.com/lerna/lerna/tree/master/commands/version). Wait for the PR to be merged.
- - After it's merged create and push a new tag, named after the version number with a "v" prefix, e.g. `v1.2.3`. Alternatively you can use the npm provided tool [npm-version](https://docs.npmjs.com/cli/version)
+ - To release a new version run the command `npm run bump-version -- [major | minor | patch]`. This will take care of updating the version number in all package.json files.
+ - Commit and push the changes you made to package files and open a PR.
+ - After the PR is merged create and push a new tag, named after the version number with a "v" prefix, e.g. `v1.2.3`. Alternatively you can use the npm provided tool [npm-version](https://docs.npmjs.com/cli/version)
  - Then go to the GitHub repository and create a new release out of that tag, describing what changed, like in the image below.
 
 <center>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:storybook:extract-stories": "lerna run build:extract-stories --scope @wmde/wikit-vue-components",
     "build:storybook:compose": "cp -r vue-components/storybook-static docs/dist/vue-components",
     "chromatic": "lerna run chromatic --scope @wmde/wikit-vue-components",
+    "bump-version": "lerna version --no-git-tag-version",
     "publish-tokens-vue": "lerna publish from-package --yes"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a script to manage versioning when making new releases. This prevents lerna from pushing incorrect tags automatically, and gives developers more control on what is committed with a version bump change.