### PR TITLE
TextInput: use <label> for the label

### DIFF
--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -1,7 +1,8 @@
 <template>
-	<label :class="[ 'wikit', 'wikit-TextInput', `wikit-TextInput--${width}` ]">
-		<div class="wikit-TextInput__label">{{ label }}</div>
+	<div :class="[ 'wikit', 'wikit-TextInput', `wikit-TextInput--${width}` ]">
+		<label class="wikit-TextInput__label" :for="id">{{ label }}</label>
 		<Input
+			:id="id"
 			:value="value"
 			@input="emitInputEvent"
 			:feedback-type="feedbackType"
@@ -13,7 +14,7 @@
 			:type="error.type"
 			:message="error.message"
 		/>
-	</label>
+	</div>
 </template>
 
 <script lang="ts">
@@ -64,6 +65,13 @@ export default Vue.extend( {
 		},
 	},
 
+	data() {
+		return {
+			// https://github.com/vuejs/vue/issues/5886
+			id: `wikit-TextInput-${Math.floor( Math.random() * 1000000 )}`,
+		};
+	},
+
 	methods: {
 		emitInputEvent( value: string ): void {
 			/**
@@ -88,8 +96,6 @@ export default Vue.extend( {
 
 <style lang="scss">
 .wikit-TextInput {
-	display: block;
-
 	&--small {
 		width: $wikit-TextInput-small-width;
 	}
@@ -108,6 +114,7 @@ export default Vue.extend( {
 
 	&__label {
 		@include Label;
+		display: block;
 	}
 }
 </style>

--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -21,6 +21,7 @@
 import Vue from 'vue';
 import ValidationMessage from './ValidationMessage.vue';
 import Input from './Input.vue';
+import generateUid from '@/components/util/generateUid';
 
 /**
  * Text input fields are form elements that let users input and edit values in the form of text.
@@ -68,7 +69,7 @@ export default Vue.extend( {
 	data() {
 		return {
 			// https://github.com/vuejs/vue/issues/5886
-			id: `wikit-TextInput-${Math.floor( Math.random() * 1000000 )}`,
+			id: generateUid( 'wikit-TextInput' ),
 		};
 	},
 

--- a/vue-components/src/components/util/generateUid.ts
+++ b/vue-components/src/components/util/generateUid.ts
@@ -1,0 +1,9 @@
+/**
+ * Generates an ID that can be used within components, e.g. for binding an input id to a label's `for` attribute
+ *
+ * @param {string} componentName
+ * @return {string}
+ */
+export default function ( componentName: string ): string {
+	return `${componentName}-${Math.floor( Math.random() * 1000000 )}`;
+}

--- a/vue-components/tests/unit/components/util/generateUid.spec.ts
+++ b/vue-components/tests/unit/components/util/generateUid.spec.ts
@@ -1,0 +1,15 @@
+import generateUid from '@/components/util/generateUid';
+
+describe( 'generateUid', () => {
+
+	it( 'generates an id prefixed with the component name', () => {
+		const componentName = 'my-component';
+		expect( generateUid( componentName ) ).toMatch( new RegExp( `${componentName}-\\d+` ) );
+	} );
+
+	it( 'does not produce the same id twice', () => {
+		const componentName = 'my-other-component';
+		expect( generateUid( componentName ) ).not.toEqual( generateUid( componentName ) );
+	} );
+
+} );


### PR DESCRIPTION
Wrapping the label around the input element became questionable as soo
as we also included the validation message in the TextInput component.
We originally went with the label as the root element of the component
to work around having to generate an id for it.

According to the WCAG having the `for`-attribute is also beneficial for
screenreaders:
https://www.w3.org/TR/2008/WD-WCAG20-TECHS-20080430/H44.html