### PR TITLE
Use latest version of wikimedi-ui-base

### DIFF
--- a/docs/src/00-doc/05-decisions-and-ADRs/adr/0012-remove-widths.stories.mdx
+++ b/docs/src/00-doc/05-decisions-and-ADRs/adr/0012-remove-widths.stories.mdx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Documentation/Decisions and ADRs/ADRs/0012) Remove predefined widths" />
+
+# 12) Remove predefined component widths
+
+Date: 2020-11-10
+
+## Status
+
+Proposed
+
+## Context
+
+Originally, block-level system components – those which size is not defined by their content (e.g. input field) – were designed and implemented following a set of predefined default widths based on the system's spacing unit (the most common size being 256px, for example). 
+These components were also designed and implemented to take a "full-width" value as a prop, intended to make them responsive and adjustable to their context via their containers.
+
+While these predefined widths were purely provided as orientation, we inferred that they might be unused after all due to the variability of contexts in which components can be implemented. 
+Making components full-width by default would simplify things: making them more versatile, responsive and adjustable to the layout of their application. 
+
+## Considered actions
+
+### 1. Keep predefined widths, but make "full-width" the default value.
+
+This conservative approach would make block-level components "full-width" by default via prop. Predefined width values are still available to be applied.
+
+### 2. Get rid of widths entirely and make components' sizes to be limited to the full width of their parent element.
+
+This involves removing all predefined widths and width props. As long as they're block-level, components will take the width of their container.
+
+## Decision
+
+Remove width props and make component widths 100% by default, so their final width is defined in context, by their layout elements. 
+Implementers will still be able to use system dimension tokens to size the containers in their application.
+
+## Consequences
+
+At this initial state, WiKit doesn't provide a layout or grid system. This means that the decision regarding the specific width of components is delegated to the designers and the developers implementing the WiKit Design system.

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -7166,9 +7166,9 @@
 			"dev": true
 		},
 		"wikimedia-ui-base": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.15.0.tgz",
-			"integrity": "sha512-t2GoyqANK41B9VkEgw1gfksDRZfj2+XXbAPgn/CYWk2CrEqZj1LiNrBTcGJ59DWCtUUwgV4MKCfm6Db+cp1Pow==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.17.0.tgz",
+			"integrity": "sha512-Gqyb4bawT+yaiXaeUjeQhNwv+YJe3N6EtMalwqWCALD23FY2C+dFcAEAQ2puW6jt4WW/rRw6uNXS5w3EfvsuYw==",
 			"dev": true
 		},
 		"word-wrap": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -40,6 +40,6 @@
     "string.prototype.matchall": "^4.0.2",
     "style-dictionary": "^2.10.2",
     "watch": "^1.0.2",
-    "wikimedia-ui-base": "^0.15.0"
+    "wikimedia-ui-base": "^0.17.0"
   }
 }

--- a/tokens/properties/global.json
+++ b/tokens/properties/global.json
@@ -92,9 +92,12 @@
             },
             "purple": {
 <<<<<<< HEAD
+<<<<<<< HEAD
                 "value": "#6b4ba1"
             }
 =======
+=======
+>>>>>>> uptade wikimedia-ui-base dependency and global tokens
                     "value": "{wmf-wmui-color-purple50.value}"
                 }
 >>>>>>> uptade wikimedia-ui-base dependency and global tokens

--- a/tokens/properties/global.json
+++ b/tokens/properties/global.json
@@ -78,21 +78,26 @@
         "modifier": {
             "lighten": {
                 "base-10": {
-                    "value": "#404244"
+                    "value": "{wmf-wmui-color-base10--lighten.value}"
                 },
                 "base-20": {
                     "value": "#6c7378"
                 },
                 "accent-50": {
-                    "value": "#447ff5"
+                    "value": "{wmf-wmui-color-accent50--lighten.value}"
                 },
                 "utility-red-50": {
-                    "value": "#ff4242"
+                    "value": "{wmf-wmui-color-red50--lighten.value}"
                 }
             },
             "purple": {
+<<<<<<< HEAD
                 "value": "#6b4ba1"
             }
+=======
+                    "value": "{wmf-wmui-color-purple50.value}"
+                }
+>>>>>>> uptade wikimedia-ui-base dependency and global tokens
         },
         "transparent": {
             "value": "transparent"
@@ -129,20 +134,17 @@
         },
         "weight": {
             "hairline": {
-                "value": "100",
-                "comment": "To be found in wmf-font-weight-hairline in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-hairline.value}"
             },
             "regular": {
-                "value": "400",
-                "comment": "To be found in wmf-font-weight-regular in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-normal.value}",
+                "comment": "Opting to not modify the name of this global token. Regular is the right typographic term for this weight."
             },
             "semi-bold": {
-                "value": "600",
-                "comment": "To be found in wmf-font-weight-semi-bold in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-semi-bold.value}"
             },
             "bold": {
-                "value": "700",
-                "comment": "To be found in wmf-font-weight-bold in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-bold.value}"
             }
         },
         "line-height": {


### PR DESCRIPTION
Makes WiKit to use the latest version of wikimedia-ui-base, [0.17.0](https://www.npmjs.com/package/wikimedia-ui-base). The values of global tokens have been replaced by cherry-picked variables whenever possible.

Bug: https://phabricator.wikimedia.org/T263722