### PR TITLE
Lookup: add "no match found" behavior

### DIFF
--- a/tokens/properties/components/LookupMenu.json
+++ b/tokens/properties/components/LookupMenu.json
@@ -92,6 +92,29 @@
 					"value": "{font.color.base.value}"
 				}
 			}
+		},
+		"no-results": {
+			"padding-vertical": {
+				"value": "{dimension.spacing.small.value}"
+			},
+			"padding-horizontal": {
+				"value": "{dimension.spacing.medium.value}"
+			},
+			"font-family": {
+				"value": "{font.family.style.label.value}"
+			},
+			"font-size": {
+				"value": "{font.size.style.label.value}"
+			},
+			"font-weight": {
+				"value": "{font.weight.style.label.value}"
+			},
+			"line-height": {
+				"value": "{font.line-height.style.label.value}"
+			},
+			"font-color": {
+				"value": "{font.color.subtle.value}"
+			}
 		}
 	}
 }

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -8,11 +8,6 @@ module.exports = {
 	custom_commands_path: 'tests/e2e/custom-commands',
 	globals_path: 'tests/e2e/globals.js',
 
-	test_workers: {
-		enabled: true,
-		workers: 'auto',
-	},
-
 	test_settings: {
 		// full default config at
 		// https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-e2e-nightwatch/nightwatch.config.js

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -16,7 +16,11 @@
 			:menu-items="menuItems"
 			v-if="showsMenu"
 			@select="onSelect"
-		/>
+		>
+			<template v-slot:no-results>
+				<slot name="no-results" />
+			</template>
+		</LookupMenu>
 		<ValidationMessage
 			v-if="error"
 			:type="error.type"

--- a/vue-components/src/components/LookupMenu.vue
+++ b/vue-components/src/components/LookupMenu.vue
@@ -69,6 +69,7 @@ $base: '.wikit-LookupMenu';
 	border: $wikit-LookupMenu-border-width $wikit-LookupMenu-border-style $wikit-LookupMenu-border-color;
 	box-shadow: $wikit-LookupMenu-box-shadow;
 	overflow-y: auto;
+	box-sizing: border-box;
 
 	&__item {
 		padding-block: $wikit-LookupMenu-item-padding-vertical;

--- a/vue-components/src/components/LookupMenu.vue
+++ b/vue-components/src/components/LookupMenu.vue
@@ -15,6 +15,9 @@
 				{{ menuItem.description }}
 			</div>
 		</div>
+		<div v-if="menuItems.length === 0" class="wikit-LookupMenu__no-results">
+			<slot name="no-results" />
+		</div>
 	</div>
 </template>
 
@@ -106,6 +109,16 @@ $base: '.wikit-LookupMenu';
 			color: $wikit-LookupMenu-item-description-font-color;
 			line-height: $wikit-LookupMenu-item-description-line-height;
 		}
+	}
+
+	&__no-results {
+		font-family: $wikit-LookupMenu-no-results-font-family;
+		font-size: $wikit-LookupMenu-no-results-font-size;
+		font-weight: $wikit-LookupMenu-no-results-font-weight;
+		color: $wikit-LookupMenu-no-results-font-color;
+		line-height: $wikit-LookupMenu-no-results-line-height;
+		padding-block: $wikit-LookupMenu-no-results-padding-vertical;
+		padding-inline: $wikit-LookupMenu-no-results-padding-horizontal;
 	}
 }
 </style>

--- a/vue-components/stories/Lookup.stories.ts
+++ b/vue-components/stories/Lookup.stories.ts
@@ -70,7 +70,11 @@ export function all(): Component {
 					:menu-items="menuItems"
 					placeholder="Placeholder"
 					width="medium"
-				/>
+				>
+					<template v-slot:no-results>
+						No match was found
+					</template>
+				</Lookup>
 				<div v-if="selectedItem" style="margin-top: 16px">
 					Selected vegetable:
 					<span class="selected-item-label">{{ selectedItem.label }}</span>

--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -1,0 +1,32 @@
+module.exports = {
+	'Lookup Menu shows on user input': ( client ) => {
+		client
+			.init()
+			.openComponentStory( 'lookup' )
+			.waitForElementPresent( '.wikit-Lookup' )
+			.setValue( 'input', 'potato' )
+			.waitForElementPresent( '.wikit-Lookup__menu' )
+			.assert.visible( '.wikit-Lookup__menu' );
+	},
+	'Lookup Menu displays no-results text on no matches found': ( client ) => {
+		client
+			.init()
+			.openComponentStory( 'lookup' )
+			.waitForElementPresent( '.wikit-Lookup' )
+			.setValue( 'input', 'whatever' )
+			.waitForElementPresent( '.wikit-Lookup__menu' )
+			.assert.containsText( '.wikit-LookupMenu__no-results', 'No match was found' );
+	},
+	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
+		client
+			.init()
+			.openComponentStory( 'lookup' )
+			.waitForElementPresent( '.wikit-Lookup' )
+			.setValue( 'input', 'potato' )
+			.waitForElementPresent( '.wikit-Lookup__menu' )
+			.assert.visible( '.wikit-LookupMenu__item' )
+			.click( '.wikit-LookupMenu__item' )
+			.assert.containsText( '.selected-item-label', 'potato' )
+			.assert.containsText( '.selected-item-id', 'Q10998' );
+	},
+};

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -194,4 +194,22 @@ describe( 'Lookup', () => {
 		expect( ( wrapper.emitted( 'update:searchInput' ) )![ 0 ] ).toEqual( [ userInput ] );
 	} );
 
+	it( 'passes the no-results slot to the lookup menu', async () => {
+		const noResultsText = 'no results :(';
+		const wrapper = mount( Lookup, {
+			propsData: {
+				menuItems: [],
+				searchInput: 'some non-empty input',
+			},
+			slots: {
+				'no-results': noResultsText,
+			},
+		} );
+		wrapper.findComponent( Input ).trigger( 'focus' );
+
+		await Vue.nextTick();
+
+		expect( wrapper.find( '.wikit-Lookup__menu' ).text() ).toBe( noResultsText );
+	} );
+
 } );

--- a/vue-components/tests/unit/components/LookupMenu.spec.ts
+++ b/vue-components/tests/unit/components/LookupMenu.spec.ts
@@ -20,4 +20,34 @@ describe( 'LookupMenu', () => {
 		expect( renderedMenuItems.at( 1 ).find( '.wikit-LookupMenu__item__description' ).text() )
 			.toBe( menuItems[ 1 ].description );
 	} );
+
+	it( 'shows the "no match found" text if there are no menu items', () => {
+		const noResultsFoundText = 'no results. so sad.';
+		const wrapper = mount( LookupMenu, {
+			propsData: {
+				menuItems: [],
+			},
+			slots: {
+				'no-results': noResultsFoundText,
+			},
+		} );
+
+		expect( wrapper.text() ).toBe( noResultsFoundText );
+	} );
+
+	it( 'does not show the "no match found" text if there are menu items', () => {
+		const wrapper = mount( LookupMenu, {
+			propsData: {
+				menuItems: [
+					{ label: 'potato', description: 'root vegetable' },
+					{ label: 'duck', description: 'aquatic bird' },
+				],
+			},
+			slots: {
+				'no-results': 'no results. so sad.',
+			},
+		} );
+
+		expect( wrapper.find( '.wikit-LookupMenu__no-results' ).exists() ).toBeFalsy();
+	} );
 } );


### PR DESCRIPTION
We implemented the "no match found" text with a slot as opposed to a
prop anticipating future requirements to also show markup and/or links
when no results were found.

Bug: [T265010](https://phabricator.wikimedia.org/T265010)