### PR TITLE
Use correct icons for message types

### DIFF
--- a/vue-components/src/components/Message.vue
+++ b/vue-components/src/components/Message.vue
@@ -9,7 +9,7 @@
 		<span class="wikit-Message__content">
 			<Icon
 				class="wikit-Message__icon"
-				:type="type === 'error' ? 'error' : 'alert'"
+				:type="getIconType"
 				:color="type"
 				size="large"
 			/>
@@ -40,7 +40,18 @@ export default Vue.extend( {
 			default: false,
 		},
 	},
-
+	computed: {
+		getIconType(): string {
+			const messageIconTypeMap = {
+				error: 'error',
+				warning: 'alert',
+				notice: 'info',
+				success: 'checkmark',
+			};
+			const messageType = this.type as 'warning'|'error'|'notice'|'success';
+			return messageIconTypeMap[ messageType ];
+		},
+	},
 	components: {
 		Icon,
 	},


### PR DESCRIPTION
The extra icons were added in #230 (cb1bcb200757564c4ee87a5c115603fa4e3377c7) for [T265582](https://phabricator.wikimedia.org/T265582), so they can now be used in this Message component.

Bug: [T265583](https://phabricator.wikimedia.org/T265583)