### PR TITLE
Use TypeScript enums for icon types

### DIFF
--- a/vue-components/src/components/Icon.vue
+++ b/vue-components/src/components/Icon.vue
@@ -7,7 +7,7 @@
 			viewBox="0 0 16 16"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			v-if="type === 'error'"
+			v-if="type === IconTypes.ERROR"
 		>
 			<path
 				fill="currentColor"
@@ -23,7 +23,7 @@
 			viewBox="0 0 16 16"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			v-else-if="type === 'alert'"
+			v-else-if="type === IconTypes.ALERT"
 		>
 			<path fill="currentColor" d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z" />
 		</svg>
@@ -34,7 +34,7 @@
 			viewBox="0 0 20 20"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			v-else-if="type === 'info'"
+			v-else-if="type === IconTypes.INFO"
 		>
 			<path fill="currentColor" d="M10 0C4.477 0 0 4.477 0 10C0 15.523 4.477 20 10 20C15.523 20 20 15.523 20 10C20 4.477 15.523 0 10 0ZM9 5H11V7H9V5ZM9 9H11V15H9V9Z" />
 		</svg>
@@ -45,7 +45,7 @@
 			viewBox="0 0 20 20"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
-			v-else-if="type === 'checkmark'"
+			v-else-if="type === IconTypes.CHECKMARK"
 		>
 			<path fill="currentColor" d="M6.34812 14.6259L1.6041 9.65425L0 11.3353L6.34812 18L20 3.693L18.3959 2L6.34812 14.6259Z" />
 		</svg>
@@ -55,7 +55,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { iconTypes, iconColors, iconSizes } from './iconProps';
+import { IconTypes, iconColors, iconSizes } from './iconProps';
 
 /**
  * Every SVG icon that is added to this component needs to have at least one element (e.g. a `<path>`) with
@@ -67,12 +67,13 @@ import { iconTypes, iconColors, iconSizes } from './iconProps';
  */
 export default Vue.extend( {
 	name: 'Icon',
+	data: () => { return { IconTypes }; },
 
 	props: {
 		type: {
 			type: String,
 			validator( value: string ): boolean {
-				return iconTypes.includes( value );
+				return Object.values( IconTypes ).includes( value as IconTypes );
 			},
 			required: true,
 		},

--- a/vue-components/src/components/Message.vue
+++ b/vue-components/src/components/Message.vue
@@ -21,6 +21,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Icon from './Icon.vue';
+import { IconTypes } from '@/components/iconProps';
 
 /**
  * Uses the following components internally: Icon
@@ -43,10 +44,10 @@ export default Vue.extend( {
 	computed: {
 		getIconType(): string {
 			const messageIconTypeMap = {
-				error: 'error',
-				warning: 'alert',
-				notice: 'info',
-				success: 'checkmark',
+				error: IconTypes.ERROR,
+				warning: IconTypes.ALERT,
+				notice: IconTypes.INFO,
+				success: IconTypes.CHECKMARK,
 			};
 			const messageType = this.type as 'warning'|'error'|'notice'|'success';
 			return messageIconTypeMap[ messageType ];

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -1,4 +1,9 @@
-export const iconTypes = [ 'alert', 'error', 'info', 'checkmark' ];
+export enum IconTypes {
+	ALERT = 'alert',
+	ERROR = 'error',
+	INFO = 'info',
+	CHECKMARK = 'checkmark',
+}
 
 export const iconColors = [ 'base', 'warning', 'error', 'notice', 'success' ];
 

--- a/vue-components/stories/Icon.stories.ts
+++ b/vue-components/stories/Icon.stories.ts
@@ -1,5 +1,5 @@
 import Icon from '@/components/Icon';
-import { iconSizes, iconColors, iconTypes } from '@/components/iconProps';
+import { iconSizes, iconColors, IconTypes } from '@/components/iconProps';
 import { Component } from 'vue';
 
 export default {
@@ -10,12 +10,12 @@ export default {
 export function allTypes(): Component {
 	return {
 		data(): object {
-			return { iconTypes };
+			return { IconTypes };
 		},
 		components: { Icon },
 		template: `
 			<div>
-				<div v-for="type in iconTypes" style="float: left; padding: 20px 50px; color: #555">
+				<div v-for="type in IconTypes" style="float: left; padding: 20px 50px; color: #555">
 					<Icon :type="type" />
 					{{ type }}
 				</div>

--- a/vue-components/tests/unit/components/Icon.spec.ts
+++ b/vue-components/tests/unit/components/Icon.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import Icon from '@/components/Icon.vue';
-import { iconSizes, iconColors, iconTypes } from '@/components/iconProps';
+import { iconSizes, iconColors, IconTypes } from '@/components/iconProps';
 
 describe( 'Icon', () => {
 
@@ -50,7 +50,9 @@ describe( 'Icon', () => {
 		} ) ).toThrow();
 	} );
 
-	it.each( iconTypes )( '%s: has at least one part of the SVG element that can be colored', ( iconType ) => {
+	it.each(
+		Object.values( IconTypes ),
+	)( '%s: has at least one part of the SVG element that can be colored', ( iconType ) => {
 		const wrapper = mount( Icon, {
 			propsData: {
 				type: iconType,


### PR DESCRIPTION
An enum seems to be the appropriate data structure for enumerating the valid types of an Icon.

This PR sits on top of #233 to better showcase how those Enums would be used, but it is primarily intended for discussion.

What do you all think? Does using the `enum` data-structure more (like in [Bridge](https://github.com/wikimedia/mediawiki-extensions-Wikibase/tree/master/client/data-bridge/src/definitions)) make sense to you?