### PR TITLE
Improved editor support for token files through JSON schemas generated via style-dictionary

### DIFF
--- a/docs/src/00-doc/03-create-reusable-components/03_developing_components.stories.mdx
+++ b/docs/src/00-doc/03-create-reusable-components/03_developing_components.stories.mdx
@@ -49,6 +49,32 @@ While a "hover" on the "Dropdown" component impacting the "menu-item" style yiel
 
 <code>wikit-<strong>Dropdown-progressive-hover</strong>-menu-item-background-color</code>
 
+## Getting better editor support for token files
+
+By generating a JSON schema describing the structure of token files and including all token names we make it possible for text editors to provide autocompletion in token JSON files. This is especially useful for token references (e.g. `{font.line-height.style.label.value}`) which would otherwise be typed by hand.
+
+Letting the text editor know which JSON files to apply the schema to requires some configuration.
+
+### VS Code
+
+VS Code has good [documentation](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) on getting better editor support for JSON files and working with JSON schemas. TL;DR modify and copy the following into your JSON workspace settings:
+
+```json
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "tokens/properties/**/*.json"
+            ],
+            "url": "./tokens/dist/schema.json"
+        }
+    ]
+}
+```
+
+### JetBrains products
+Go to Settings and navigate to `Languages & Frameworks` > `Schemas and DTDs` >  `JSON Schema Mappings`. There you'll be able to create a mapping for the token files with the schema pointing to `./tokens/dist/schema.json` and the directory set to `tokens/properties/`.
+
 ## Testing Components
 
 ### Working with browser tests

--- a/tokens/.style-dictionary/config.js
+++ b/tokens/.style-dictionary/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const StyleDictionary = require( 'style-dictionary' ),
+	tokenSchema = require( './token-schema.json' ),
 	{ removeWikimediaUiBaseVars, getReferencedTokens, kebabCase } = require( './lib' ),
 	wikitStyleDictionary = StyleDictionary.extend( {
 		include: [ 'node_modules/wikimedia-ui-base/tokens.json' ],
@@ -55,6 +56,14 @@ const StyleDictionary = require( 'style-dictionary' ),
 					filter: removeWikimediaUiBaseVars,
 				} ],
 			},
+			jsonSchema: {
+				transforms: StyleDictionary.transformGroup.web,
+				buildPath: 'dist/',
+				files: [ {
+					destination: 'schema.json',
+					format: 'jsonSchema',
+				} ],
+			},
 		},
 	} );
 
@@ -68,6 +77,20 @@ wikitStyleDictionary.registerTransform( {
 	name: 'name/kebabCase',
 	type: 'name',
 	transformer: kebabCase,
+} );
+
+wikitStyleDictionary.registerFormat( {
+	name: 'jsonSchema',
+	formatter( dictionary ) {
+		tokenSchema.definitions.tokenReference = {
+			type: 'string',
+			enum: dictionary.allProperties.map(
+				( token ) => `{${token.path.join( '.' )}.value}`,
+			),
+		};
+
+		return JSON.stringify( tokenSchema );
+	},
 } );
 
 wikitStyleDictionary.buildAllPlatforms();

--- a/tokens/.style-dictionary/token-schema.json
+++ b/tokens/.style-dictionary/token-schema.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+
+    "definitions": {
+        "tokenReference": {
+            "$comment": "The contents of definitions.tokenReference will be overridden at built time with an enum of all possible token names"
+        }
+    },
+
+    "type": "object",
+    "patternProperties": {
+        ".*": {
+            "$comment": "Recursively declaring all properties to either be a(nother) nesting level, or a token",
+            "anyOf": [
+                {
+                    "$comment": "a token with a value",
+
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "anyOf": [
+                                { "$ref": "#/definitions/tokenReference" },
+                                {
+                                    "$comment": "Not every value is a token reference. It can also be a plain string.",
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "value"
+                    ]
+                },
+                {
+                    "$comment": "a nesting level (`#` refers to the schema itself)",
+                    "$ref": "#"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Generating a JSON schema describing the structure of token files and including all token names makes it possible for text editors to provide autocompletion in token JSON files. This is especially useful for token references (e.g. `{font.line-height.style.label.value}`) which would otherwise be typed by hand.

<img width="611" alt="Screenshot 2020-10-24 at 22 56 52" src="https://user-images.githubusercontent.com/453024/97103551-6edc0b80-16ad-11eb-8dbc-1e8f0d3e7e32.png">

## Want!! How??
Letting the text editor know which JSON files to apply the schema to requires some configuration. I tried it out with VS Code and Intellij.

### VS Code
VS Code has good [documentation](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) on getting better editor support for JSON files and working with JSON schemas. TL;DR paste the following into your JSON workspace settings:
```json
{
    "json.schemas": [
        {
            "fileMatch": [
                "tokens/properties/**/*.json"
            ],
            "url": "./tokens/dist/schema.json"
        }
    ]
}
```

### Intellij/Webstorm/PHPStorm
Create an entry in your JSON schema settings.

<img width="1118" alt="Screenshot 2020-10-25 at 11 42 53" src="https://user-images.githubusercontent.com/453024/97104861-553fc180-16b7-11eb-8c12-0af03eaf5fce.png">
