### PR TITLE
docs: list/visualize component-level tokens

### DIFF
--- a/docs/.storybook/main.js
+++ b/docs/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-	stories: [ '../src/**/*.stories.@(js|mdx)' ],
+	stories: [ '../src/**/*.stories.@(js|mdx|jsx)' ],
 	addons: [
 		'@storybook/addon-a11y',
 		'@storybook/addon-docs',

--- a/docs/src/10-component-tokens/components.stories.jsx
+++ b/docs/src/10-component-tokens/components.stories.jsx
@@ -1,0 +1,21 @@
+import tokens from '@wmde/wikit-tokens/dist/index.json';
+import { flattenTokenTree } from '../lib/flattenTokenTree';
+import { storiesOf } from '@storybook/react'; // TODO
+import React from 'react';
+import { TokenTable } from '../lib/TokenTable';
+
+const groupedTokens = {};
+flattenTokenTree( tokens )
+	.filter( ( token ) => {
+		return token.path[0].indexOf( 'wikit-' ) !== -1;
+	} )
+	.forEach( ( token ) => {
+		const component = token.name.split( '-' )[1]; // component name is the second part after 'wikit-'
+		groupedTokens[ component ] = groupedTokens[ component ] || [];
+		groupedTokens[ component ].push( token );
+	} );
+
+for ( let key in groupedTokens ) {
+	storiesOf( 'Component tokens', module )
+		.add( key, () => <TokenTable tokens={ groupedTokens[ key ] } /> );
+}

--- a/docs/src/lib/TokenTable.jsx
+++ b/docs/src/lib/TokenTable.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { TokenPresenter } from './TokenPresenter';
-import { components } from '@storybook/components/dist/typography/DocumentFormatting';
-import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx';
+// import { components } from '@storybook/components/dist/typography/DocumentFormatting'; // TODO
+// import { AnchorMdx } from '@storybook/addon-docs/dist/blocks/mdx'; // TODO
 import './../styles/token-table.css';
 
 export function TokenTable( { tokens } ) {
 	return (
-		<components.table className='token-table' style={{ width: '100%' }}>
+		<table className='token-table' style={{ width: '100%' }}>
 			<thead>
 				<tr>
 					<th>Name</th>
@@ -18,7 +18,7 @@ export function TokenTable( { tokens } ) {
 					tokens.map( ( token ) => (
 						<tr key={ token.name } id={ token.name }>
 							<td>
-								<AnchorMdx href={ '#' + token.name }>🔗</AnchorMdx>
+								<a href={ '#' + token.name }>🔗</a>
 							&nbsp;<strong className="token-name">{ token.name }</strong>
 								<div className="referenced-tokens" title="value influenced by">
 									{token.referencedTokens.length > 0 ?
@@ -38,6 +38,6 @@ export function TokenTable( { tokens } ) {
 					) )
 				}
 			</tbody>
-		</components.table>
+		</table>
 	);
 }


### PR DESCRIPTION
Gets the tokens from the tokens' module export, filters it to
component level and groups them.

The resulting stories are a function of the existing components (i.e.
dynamic) which makes things much harder than one would think it needs to
be. Find a way to dynamically create navigation entries, use our custom
components in the mark up.

Bug: https://phabricator.wikimedia.org/T260425