### PR TITLE
Disable false positive "could be null" linting error

### DIFF
--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -131,8 +131,11 @@ export default Vue.extend( {
 			 * MenuItem object.
 			 */
 			this.$emit( 'input', menuItem );
-			this.$el.querySelector( 'input' ).blur();
 			this.$emit( 'update:searchInput', menuItem.label );
+
+			// We know that there is one input here because it is part of this component
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			this.$el.querySelector( 'input' )!.blur();
 		},
 	},
 


### PR DESCRIPTION
I decided against using `this.$el.querySelector( 'input' )?.blur();` as this error is actually a case of a false positive and I wanted to make that obvious and explicit.