### PR TITLE
Add stories for the internal LookupMenu component

### DIFF
--- a/vue-components/stories/Lookup.stories.ts
+++ b/vue-components/stories/Lookup.stories.ts
@@ -4,7 +4,7 @@ import { MenuItem } from '@/components/MenuItem';
 
 export default {
 	component: Lookup,
-	title: 'Lookup',
+	title: '/Lookup/Lookup',
 };
 
 const vegetableItems = [

--- a/vue-components/stories/LookupMenu.stories.ts
+++ b/vue-components/stories/LookupMenu.stories.ts
@@ -1,0 +1,84 @@
+import LookupMenu from '@/components/LookupMenu';
+import { Component } from 'vue';
+import { MenuItem } from '@/components/MenuItem';
+
+export default {
+	component: LookupMenu,
+	title: '/Lookup/LookupMenu',
+};
+
+const vegetableItems = [
+	{
+		label: 'potato',
+		description: 'root vegetable',
+		value: 'Q10998',
+	},
+	{
+		label: 'carrot',
+		description: 'root vegetable, usually orange in color',
+		value: 'Q81',
+	},
+	{
+		label: 'zucchini',
+		description: 'Edible summer squash, typically green in colour',
+		value: 'Q7533',
+	},
+	{
+		label: 'eggplant',
+		description: 'plant species Solanum melongena',
+		value: 'Q7540',
+	},
+	{
+		label: 'broccoli',
+		description: 'edible green plant in the cabbage family',
+		value: 'Q47722',
+	},
+	{
+		label: 'cauliflower',
+		description: 'vegetable, for the plant see Q7537 (Brassica oleracea var. botrytis)',
+		value: 'Q23900272',
+	},
+	{
+		label: 'brussels sprouts',
+		description: 'vegetable',
+		value: 'Q150463',
+	},
+];
+
+export function withItems(): Component {
+	return {
+		components: { LookupMenu },
+		computed: {
+			menuItems(): MenuItem[] {
+				return vegetableItems;
+			},
+		},
+
+		template: `
+			<div>
+				<LookupMenu
+					:menu-items="menuItems"
+				>
+				</LookupMenu>
+			</div>
+		`,
+	};
+}
+
+export function noItems(): Component {
+	return {
+		components: { LookupMenu },
+
+		template: `
+			<div>
+				<LookupMenu
+					:menu-items="[]"
+				>
+                  <template v-slot:no-results>
+                    <em>Nothing</em> was found! 😢
+                  </template>
+				</LookupMenu>
+			</div>
+		`,
+	};
+}

--- a/vue-components/tests/e2e/custom-commands/openComponentStoryDirectory.js
+++ b/vue-components/tests/e2e/custom-commands/openComponentStoryDirectory.js
@@ -1,0 +1,6 @@
+module.exports.command = function openComponentStoryDirectory( componentDirectory ) {
+	const directorySelector = `a[href="#${componentDirectory}"]`;
+	return this.waitForElementPresent( '#root' )
+		.click( directorySelector )
+		.waitForElementPresent( `${directorySelector} + div` );
+};

--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -2,7 +2,8 @@ module.exports = {
 	'Lookup Menu shows on user input': ( client ) => {
 		client
 			.init()
-			.openComponentStory( 'lookup' )
+			.openComponentStoryDirectory( 'lookup' )
+			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'potato' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
@@ -11,7 +12,8 @@ module.exports = {
 	'Lookup Menu displays no-results text on no matches found': ( client ) => {
 		client
 			.init()
-			.openComponentStory( 'lookup' )
+			.openComponentStoryDirectory( 'lookup' )
+			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'whatever' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
@@ -20,7 +22,8 @@ module.exports = {
 	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
 		client
 			.init()
-			.openComponentStory( 'lookup' )
+			.openComponentStoryDirectory( 'lookup' )
+			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'potato' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )


### PR DESCRIPTION
This will be used for design verification and visual regression testing.
That seems in particular important for possible upcoming refactoring for
this component.

Behavior has to still be evaluated with the actual component.