### PR TITLE
add white-space property to button component

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -54,6 +54,7 @@ $base: '.wikit-Button';
 	transition-duration: $wikit-Button-transition-duration;
 	transition-timing-function: $wikit-Button-transition-timing-function;
 	transition-property: $wikit-Button-transition-property;
+	white-space: nowrap;
 
 	// TODO use breakpoint mixin?
 	@media (max-width: $width-breakpoint-mobile) {


### PR DESCRIPTION
This makes sure our buttons only contain single-line text, which is recommended from a design standpoint.