### PR TITLE
Bump version to 1.2.0-alpha.0

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-docs",
-	"version": "1.1.2",
+	"version": "1.2.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.2.0-alpha.0",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist -s src/00-doc/static"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^1.1.2",
-    "@wmde/wikit-vue-components": "^1.1.2",
+    "@wmde/wikit-tokens": "^1.2.0-alpha.0",
+    "@wmde/wikit-vue-components": "^1.2.0-alpha.0",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "1.1.2"
+  "version": "1.2.0-alpha.0"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-tokens",
-	"version": "1.1.2",
+	"version": "1.2.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "1.1.2",
+  "version": "1.2.0-alpha.0",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-vue-components",
-	"version": "1.1.2",
+	"version": "1.2.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "1.1.2",
+  "version": "1.2.0-alpha.0",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -33,7 +33,7 @@
   ],
   "types": "dist/main.d.ts",
   "dependencies": {
-    "@wmde/wikit-tokens": "^1.1.2",
+    "@wmde/wikit-tokens": "^1.2.0-alpha.0",
     "core-js": "^3.6.5",
     "ress": "^3.0.0",
     "vue": "^2.6.11"


### PR DESCRIPTION
This pre-release allows using the both Message and the Lookup component in other work-in-progress projects while still finishing up the last aspects of the Lookup component.

The Message should already be done.

https://github.com/wmde/wikit/compare/v1.1.2..alphaLookupAndMessageRelease