### PR TITLE
vue-components: check components' wikit class on required props

### DIFF
--- a/vue-components/tests/unit/components.spec.ts
+++ b/vue-components/tests/unit/components.spec.ts
@@ -3,8 +3,18 @@ import * as allComponents from '@/main';
 
 describe( 'All components', () => {
 	it( 'have the class wikit in their root node', () => {
+		// props to feed to certain components so they can be built
+		// TODO in order not to maintain this forever, consider switching this to an eslint-based solution
+		// See https://phabricator.wikimedia.org/T267741
+		const dummyProps: Record<string, object> = {
+			Message: {
+				type: 'success',
+			},
+		};
 		Object.values( allComponents ).forEach( ( component ) => {
-			const wrapper = mount( component );
+			const wrapper = mount( component, {
+				propsData: dummyProps[ ( component as any ).options.name ] || {},
+			} );
 			expect( wrapper.classes() ).toContain( 'wikit' );
 		} );
 	} );


### PR DESCRIPTION
The test was added to ensure that all components exhibit the class
"wikit" in their root node in order to be able to have a selector for
styles (resets).

At the time we missed that components may have required props which will
have to be specified to render (mount) the component.

This allows for a quick way to specify those props per component.
However, as this an endless job, I think we may be better off swapping
this jest test for something based on static analysis (e.g. inspired by
[0]). Granted, this can not do the full complexity of a vue component
justice, but we probably don't want dynamic behavior in the wikit class
anyway.

[0]: https://github.com/vuejs/eslint-plugin-vue/blob/80b8983/lib/rules/static-class-names-order.js