### PR TITLE
Fix caching issues

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -64,7 +64,6 @@ jobs:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Test
       run: npm run test
@@ -114,7 +113,6 @@ jobs:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Extract commit hash
       shell: bash

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -40,7 +40,6 @@ jobs:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Cache artifacts
       uses: actions/cache@v2

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -42,6 +42,13 @@ jobs:
           */node_modules
           */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+    - name: Cache artifacts
+      uses: actions/cache@v2
+      id: dist
+      with:
+        path: |
+          */dist
+        key: ${{ runner.os }}-${{ hashFiles('*/dist') }}
     - name: Install
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
@@ -58,13 +65,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '10.x'
-    - name: Restore cache
+    - name: Restore dependencies
       uses: actions/cache@v2
       with:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Test
       run: npm run test
@@ -82,14 +88,19 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '10.x'
-    - name: Restore cache
+    - name: Restore dependencies
       uses: actions/cache@v2
       with:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+    - name: Restore artifacts
+      uses: actions/cache@v2
+      with:
+        path: |
+          */dist
+        key: ${{ runner.os }}-${{ hashFiles('*/dist') }}
     - name: Build Storybooks
       run: npm run build:storybook
     - name: Deploy Storybook
@@ -108,13 +119,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '10.x'
-    - name: Restore cache
+    - name: Restore dependencies
       uses: actions/cache@v2
       with:
         path: |
           node_modules
           */node_modules
-          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Extract commit hash
       shell: bash

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -64,6 +64,7 @@ jobs:
         path: |
           node_modules
           */node_modules
+          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Test
       run: npm run test
@@ -113,6 +114,7 @@ jobs:
         path: |
           node_modules
           */node_modules
+          */dist
         key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
     - name: Extract commit hash
       shell: bash

--- a/docs/src/00-doc/05-decisions-and-ADRs/adr/0011-visual-testing.stories.mdx
+++ b/docs/src/00-doc/05-decisions-and-ADRs/adr/0011-visual-testing.stories.mdx
@@ -20,7 +20,7 @@ There were previous unsuccessful attempts of setting up visual regression tests 
 
 For the Design System we already started using Chromatic to make it possible to deploy docs/storybook on feature branches ([T256864](https://phabricator.wikimedia.org/T256864)). Chromatic also offers a feature called [Visual tests](https://www.chromatic.com/docs/test) which performs visual regression testing on Storybook stories in Chrome.
 
-The UI tests results are automatically part of CI and are shown on the respective github PR.
+The UI tests results are automatically part of CI and are shown on the respective github PR. 
 
 ## Decision
 

--- a/docs/src/00-doc/05-decisions-and-ADRs/adr/0011-visual-testing.stories.mdx
+++ b/docs/src/00-doc/05-decisions-and-ADRs/adr/0011-visual-testing.stories.mdx
@@ -20,7 +20,7 @@ There were previous unsuccessful attempts of setting up visual regression tests 
 
 For the Design System we already started using Chromatic to make it possible to deploy docs/storybook on feature branches ([T256864](https://phabricator.wikimedia.org/T256864)). Chromatic also offers a feature called [Visual tests](https://www.chromatic.com/docs/test) which performs visual regression testing on Storybook stories in Chrome.
 
-The UI tests results are automatically part of CI and are shown on the respective github PR. 
+The UI tests results are automatically part of CI and are shown on the respective github PR.
 
 ## Decision
 


### PR DESCRIPTION
The combined artifact and dependency cache was causing issues while trying to restore it in branches that potentially make changes to the artifacts. In this PR we fix this by splitting the artifact cache (which is required for the proper deployment of storybook in the `deploy` job, from the dependency cache, which is required in all steps).

Issue: [T266460](https://phabricator.wikimedia.org/T266460)