### PR TITLE
firefox_doesnt_show_active_styles_while_LookupMenu-item_is_clicked

### DIFF
--- a/vue-components/src/components/LookupMenu.vue
+++ b/vue-components/src/components/LookupMenu.vue
@@ -10,10 +10,12 @@
 			:key="index"
 			v-for="(menuItem, index) in menuItems"
 			:class="{
-				'wikit-LookupMenu__item--selected': index === selectedItemIndex
+				'wikit-LookupMenu__item--selected': index === selectedItemIndex,
+				'wikit-LookupMenu__item--active': index === activeItemIndex,
 			}"
 			@click="$emit( 'select', menuItem )"
-			@mousedown.prevent
+			@mousedown.prevent="activeItemIndex = index"
+			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
 		>
 			<div class="wikit-LookupMenu__item__label">
@@ -41,6 +43,7 @@ export default Vue.extend( {
 	data() {
 		return {
 			maxHeight: null as number|null,
+			activeItemIndex: -1,
 		};
 	},
 	props: {
@@ -126,6 +129,8 @@ $base: '.wikit-LookupMenu';
 			cursor: $wikit-LookupMenu-item-hover-cursor;
 		}
 
+		&--active,
+		&--active:hover,
 		&:active {
 			background-color: $wikit-LookupMenu-item-active-background-color;
 


### PR DESCRIPTION
@itamargiv  thanks for the help yesterday. we did miss one thing, though.
the focus on the input is lost after selecting an item.
@micgro42 had another approach and it's working with FF and chrome (haven't tested with safari and IE)