### PR TITLE
correct wrong font color value

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -156,7 +156,7 @@
                 "value": "{color.modifier.lighten.accent-50.value}"
             },
             "progressive-active": {
-                "value": "{color.modifier.lighten.accent-50.value}"
+                "value": "{color.accent.50.value}"
             },
             "destructive": {
                 "value": "{color.utility.red.50.value}"


### PR DESCRIPTION
The value of font-color-progressive-active should be Accent 30. This is currently an unused token.