### PR TITLE
Update 0012-remove-widths.stories.mdx

### DIFF
--- a/docs/src/00-doc/05-decisions-and-ADRs/adr/0012-remove-widths.stories.mdx
+++ b/docs/src/00-doc/05-decisions-and-ADRs/adr/0012-remove-widths.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Documentation/Decisions and ADRs/ADRs/0012) Remove predefined widths" />
+<Meta title="Documentation/Decisions and ADRs/ADRs/12) Remove predefined widths" />
 
 # 12) Remove predefined component widths
 


### PR DESCRIPTION
The tiniest PR ever: this removes the two 0s placed by mistake before the ADR number