### PR TITLE
Use latest version of wikimedia-ui-base

### DIFF
--- a/tokens/package.json
+++ b/tokens/package.json
@@ -40,6 +40,6 @@
     "string.prototype.matchall": "^4.0.2",
     "style-dictionary": "^2.10.2",
     "watch": "^1.0.2",
-    "wikimedia-ui-base": "^0.15.0"
+    "wikimedia-ui-base": "^0.17.0"
   }
 }

--- a/tokens/properties/global.json
+++ b/tokens/properties/global.json
@@ -78,20 +78,20 @@
         "modifier": {
             "lighten": {
                 "base-10": {
-                    "value": "#404244"
+                    "value": "{wmf-wmui-color-base10--lighten.value}"
                 },
                 "base-20": {
                     "value": "#6c7378"
                 },
                 "accent-50": {
-                    "value": "#447ff5"
+                    "value": "{wmf-wmui-color-accent50--lighten.value}"
                 },
                 "utility-red-50": {
-                    "value": "#ff4242"
+                    "value": "{wmf-wmui-color-red50--lighten.value}"
                 }
             },
             "purple": {
-                "value": "#6b4ba1"
+                "value": "{wmf-wmui-color-purple50.value}"
             }
         },
         "transparent": {
@@ -129,20 +129,17 @@
         },
         "weight": {
             "hairline": {
-                "value": "100",
-                "comment": "To be found in wmf-font-weight-hairline in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-hairline.value}"
             },
             "regular": {
-                "value": "400",
-                "comment": "To be found in wmf-font-weight-regular in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-normal.value}",
+                "comment": "Opting to not modify the name of this global token. Regular is the right typographic term for this weight."
             },
             "semi-bold": {
-                "value": "600",
-                "comment": "To be found in wmf-font-weight-semi-bold in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-semi-bold.value}"
             },
             "bold": {
-                "value": "700",
-                "comment": "To be found in wmf-font-weight-bold in a future wikimedia-ui-base version"
+                "value": "{wmf-font-weight-bold.value}"
             }
         },
         "line-height": {


### PR DESCRIPTION
This way, our global tokens are based on the variables contained by the latest version of wikimedia-ui-base whenever possible.

Issue: https://phabricator.wikimedia.org/T263722