### PR TITLE
Make bold titles in LookupMenu optional

### DIFF
--- a/tokens/properties/components/LookupMenu.json
+++ b/tokens/properties/components/LookupMenu.json
@@ -66,7 +66,12 @@
 					"value": "{font.size.style.label.value}"
 				},
 				"font-weight": {
-					"value": "{font.weight.bold.value}"
+					"regular": {
+						"value": "{font.weight.style.label.value}"
+					},
+					"bold": {
+						"value": "{font.weight.bold.value}"
+					}
 				},
 				"line-height": {
 					"value": "{font.line-height.style.label.value}"

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -19,6 +19,7 @@
 		<LookupMenu
 			class="wikit-Lookup__menu"
 			:menu-items="menuItems"
+			:bold-labels="true"
 			v-show="showMenu"
 			@select="onSelect"
 			@scroll="onScroll"

--- a/vue-components/src/components/LookupMenu.vue
+++ b/vue-components/src/components/LookupMenu.vue
@@ -18,7 +18,12 @@
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
 		>
-			<div class="wikit-LookupMenu__item__label">
+			<div
+				:class="{
+					'wikit-LookupMenu__item__label': true,
+					'wikit-LookupMenu__item__label--bold': boldLabels,
+				}"
+			>
 				{{ menuItem.label }}
 			</div>
 			<div class="wikit-LookupMenu__item__description">
@@ -51,6 +56,13 @@ export default Vue.extend( {
 		menuItems: {
 			type: Array,
 			default: (): [] => [],
+		},
+		/**
+		 * Whether the label of the options should be bold
+		 */
+		boldLabels: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	methods: {
@@ -171,9 +183,13 @@ $base: '.wikit-LookupMenu';
 		&__label {
 			font-family: $wikit-LookupMenu-item-label-font-family;
 			font-size: $wikit-LookupMenu-item-label-font-size;
-			font-weight: $wikit-LookupMenu-item-label-font-weight;
+			font-weight: $wikit-LookupMenu-item-label-font-weight-regular;
 			color: $wikit-LookupMenu-item-label-font-color;
 			line-height: $wikit-LookupMenu-item-label-line-height;
+
+			&--bold {
+				font-weight: $wikit-LookupMenu-item-label-font-weight-bold;
+			}
 		}
 
 		&__description {

--- a/vue-components/stories/LookupMenu.stories.ts
+++ b/vue-components/stories/LookupMenu.stories.ts
@@ -29,6 +29,15 @@ const vegetableItems = [
 		value: 'Q7540',
 	},
 	{
+		label: 'tomato',
+		value: 'Q20638126',
+	},
+	{
+		label: 'potato',
+		description: '',
+		value: 'Q16587531',
+	},
+	{
 		label: 'broccoli',
 		description: 'edible green plant in the cabbage family',
 		value: 'Q47722',
@@ -45,7 +54,7 @@ const vegetableItems = [
 	},
 ];
 
-export function withItems(): Component {
+export function withItems( args: { boldLabels: boolean } ): Component {
 	return {
 		components: { LookupMenu },
 		computed: {
@@ -53,17 +62,29 @@ export function withItems(): Component {
 				return vegetableItems;
 			},
 		},
-
+		props: Object.keys( args ),
 		template: `
 			<div>
 				<LookupMenu
 					:menu-items="menuItems"
+					:bold-labels="boldLabels"
 				>
 				</LookupMenu>
 			</div>
 		`,
 	};
 }
+
+withItems.args = {
+	boldLabels: true,
+};
+withItems.argTypes = {
+	menuItems: {
+		control: {
+			disable: true,
+		},
+	},
+};
 
 export function noItems(): Component {
 	return {


### PR DESCRIPTION
This is done in preparation for remaking the LookupMenu in to a more general OptionsMenu that is then to also be used for the Dropdown. And the Dropdown has options who's label is not bold.

Two options and controls are added to the story to showcase this.

Todo:
- [x] get clarity on that we actually want to switch the boldness of options via a prop for _all_ options in a menu instead of it being decided dynamically depending on whether we are description available
- [x] we probably want to adjust the tokens in order to define the boldness of the normal-weight font (done in [46533a3](https://github.com/wmde/wikit/pull/282/commits/46533a3aefd9f983ccddb0b9f356c62d844591da))