### PR TITLE
Rename LookupMenu to OptionsMenu

### DIFF
--- a/tokens/properties/components/OptionsMenu.json
+++ b/tokens/properties/components/OptionsMenu.json
@@ -1,5 +1,5 @@
 {
-	"wikit-LookupMenu": {
+	"wikit-OptionsMenu": {
 		"background-color": {
 			"value": "{background.color.base.default.value}"
 		},

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -16,7 +16,7 @@
 			:disabled="disabled"
 			autocomplete="off"
 		/>
-		<LookupMenu
+		<OptionsMenu
 			class="wikit-Lookup__menu"
 			:menu-items="menuItems"
 			:bold-labels="true"
@@ -29,7 +29,7 @@
 			<template v-slot:no-results>
 				<slot name="no-results" />
 			</template>
-		</LookupMenu>
+		</OptionsMenu>
 		<ValidationMessage
 			v-if="error"
 			:type="error.type"
@@ -43,7 +43,7 @@ import Vue, { PropType, VueConstructor } from 'vue';
 import isEqual from 'lodash.isequal';
 import ValidationMessage from './ValidationMessage.vue';
 import Input from './Input.vue';
-import LookupMenu from './LookupMenu.vue';
+import OptionsMenu from './OptionsMenu.vue';
 import generateUid from '@/components/util/generateUid';
 import { MenuItem } from '@/components/MenuItem';
 
@@ -51,9 +51,9 @@ import { MenuItem } from '@/components/MenuItem';
  * The lookup component is a text input field that provides matching selectable suggestions as a user types into it.
  * In the context of Wikidata, they can be used as Item and Property selectors, for example.
  *
- * Uses the following components internally: Input, ValidationMessage and LookupMenu
+ * Uses the following components internally: Input, ValidationMessage and OptionsMenu
  */
-export default ( Vue as VueConstructor<Vue & { $refs: { menu: InstanceType<typeof LookupMenu> } }> ).extend( {
+export default ( Vue as VueConstructor<Vue & { $refs: { menu: InstanceType<typeof OptionsMenu> } }> ).extend( {
 	name: 'Lookup',
 	data() {
 		return {
@@ -187,7 +187,7 @@ export default ( Vue as VueConstructor<Vue & { $refs: { menu: InstanceType<typeo
 	components: {
 		Input,
 		ValidationMessage,
-		LookupMenu,
+		OptionsMenu,
 	},
 } );
 </script>

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -1,17 +1,17 @@
 <template>
 	<div
-		:class="[ 'wikit', 'wikit-LookupMenu' ]"
+		:class="[ 'wikit', 'wikit-OptionsMenu' ]"
 		@scroll.passive="onScroll"
 		ref="lookup-menu"
 		:style="{ maxHeight: maxHeight ? maxHeight + 'px' : null }"
 	>
 		<div
-			class="wikit-LookupMenu__item"
+			class="wikit-OptionsMenu__item"
 			:key="index"
 			v-for="(menuItem, index) in menuItems"
 			:class="{
-				'wikit-LookupMenu__item--selected': index === selectedItemIndex,
-				'wikit-LookupMenu__item--active': index === activeItemIndex,
+				'wikit-OptionsMenu__item--selected': index === selectedItemIndex,
+				'wikit-OptionsMenu__item--active': index === activeItemIndex,
 			}"
 			@click="$emit( 'select', menuItem )"
 			@mousedown.prevent="activeItemIndex = index"
@@ -20,17 +20,17 @@
 		>
 			<div
 				:class="{
-					'wikit-LookupMenu__item__label': true,
-					'wikit-LookupMenu__item__label--bold': boldLabels,
+					'wikit-OptionsMenu__item__label': true,
+					'wikit-OptionsMenu__item__label--bold': boldLabels,
 				}"
 			>
 				{{ menuItem.label }}
 			</div>
-			<div class="wikit-LookupMenu__item__description">
+			<div class="wikit-OptionsMenu__item__description">
 				{{ menuItem.description }}
 			</div>
 		</div>
-		<div v-if="menuItems.length === 0" class="wikit-LookupMenu__no-results">
+		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results">
 			<slot name="no-results" />
 		</div>
 	</div>
@@ -44,7 +44,7 @@ import debounce from 'lodash/debounce';
  * This is an internal component which used by the Lookup component.
  */
 export default Vue.extend( {
-	name: 'LookupMenu',
+	name: 'OptionsMenu',
 	data() {
 		return {
 			maxHeight: null as number|null,
@@ -142,73 +142,73 @@ export default Vue.extend( {
 </script>
 
 <style lang="scss">
-$base: '.wikit-LookupMenu';
+$base: '.wikit-OptionsMenu';
 
 #{$base} {
-	min-width: $wikit-LookupMenu-min-width;
-	max-width: $wikit-LookupMenu-max-width;
+	min-width: $wikit-OptionsMenu-min-width;
+	max-width: $wikit-OptionsMenu-max-width;
 	width: max-content;
-	background-color: $wikit-LookupMenu-background-color;
-	border-radius: $wikit-LookupMenu-border-radius;
-	border: $wikit-LookupMenu-border-width $wikit-LookupMenu-border-style $wikit-LookupMenu-border-color;
-	box-shadow: $wikit-LookupMenu-box-shadow;
+	background-color: $wikit-OptionsMenu-background-color;
+	border-radius: $wikit-OptionsMenu-border-radius;
+	border: $wikit-OptionsMenu-border-width $wikit-OptionsMenu-border-style $wikit-OptionsMenu-border-color;
+	box-shadow: $wikit-OptionsMenu-box-shadow;
 	overflow-y: auto;
 	box-sizing: border-box;
 	z-index: 1;
 
 	&__item {
 		position: relative;
-		padding-block: $wikit-LookupMenu-item-padding-vertical;
-		padding-inline: $wikit-LookupMenu-item-padding-horizontal;
-		transition-property: $wikit-LookupMenu-item-transition-property;
-		transition-duration: $wikit-LookupMenu-item-transition-duration;
-		transition-timing-function: $wikit-LookupMenu-item-transition-timing-function;
+		padding-block: $wikit-OptionsMenu-item-padding-vertical;
+		padding-inline: $wikit-OptionsMenu-item-padding-horizontal;
+		transition-property: $wikit-OptionsMenu-item-transition-property;
+		transition-duration: $wikit-OptionsMenu-item-transition-duration;
+		transition-timing-function: $wikit-OptionsMenu-item-transition-timing-function;
 
 		&:hover,
 		&--selected {
-			background-color: $wikit-LookupMenu-item-hover-background-color;
-			cursor: $wikit-LookupMenu-item-hover-cursor;
+			background-color: $wikit-OptionsMenu-item-hover-background-color;
+			cursor: $wikit-OptionsMenu-item-hover-cursor;
 		}
 
 		&--active,
 		&--active:hover,
 		&:active {
-			background-color: $wikit-LookupMenu-item-active-background-color;
+			background-color: $wikit-OptionsMenu-item-active-background-color;
 
 			#{$base}__item__label, #{$base}__item__description {
-				color: $wikit-LookupMenu-item-active-color;
+				color: $wikit-OptionsMenu-item-active-color;
 			}
 		}
 
 		&__label {
-			font-family: $wikit-LookupMenu-item-label-font-family;
-			font-size: $wikit-LookupMenu-item-label-font-size;
-			font-weight: $wikit-LookupMenu-item-label-font-weight-regular;
-			color: $wikit-LookupMenu-item-label-font-color;
-			line-height: $wikit-LookupMenu-item-label-line-height;
+			font-family: $wikit-OptionsMenu-item-label-font-family;
+			font-size: $wikit-OptionsMenu-item-label-font-size;
+			font-weight: $wikit-OptionsMenu-item-label-font-weight-regular;
+			color: $wikit-OptionsMenu-item-label-font-color;
+			line-height: $wikit-OptionsMenu-item-label-line-height;
 
 			&--bold {
-				font-weight: $wikit-LookupMenu-item-label-font-weight-bold;
+				font-weight: $wikit-OptionsMenu-item-label-font-weight-bold;
 			}
 		}
 
 		&__description {
-			font-family: $wikit-LookupMenu-item-description-font-family;
-			font-size: $wikit-LookupMenu-item-description-font-size;
-			font-weight: $wikit-LookupMenu-item-description-font-weight;
-			color: $wikit-LookupMenu-item-description-font-color;
-			line-height: $wikit-LookupMenu-item-description-line-height;
+			font-family: $wikit-OptionsMenu-item-description-font-family;
+			font-size: $wikit-OptionsMenu-item-description-font-size;
+			font-weight: $wikit-OptionsMenu-item-description-font-weight;
+			color: $wikit-OptionsMenu-item-description-font-color;
+			line-height: $wikit-OptionsMenu-item-description-line-height;
 		}
 	}
 
 	&__no-results {
-		font-family: $wikit-LookupMenu-no-results-font-family;
-		font-size: $wikit-LookupMenu-no-results-font-size;
-		font-weight: $wikit-LookupMenu-no-results-font-weight;
-		color: $wikit-LookupMenu-no-results-font-color;
-		line-height: $wikit-LookupMenu-no-results-line-height;
-		padding-block: $wikit-LookupMenu-no-results-padding-vertical;
-		padding-inline: $wikit-LookupMenu-no-results-padding-horizontal;
+		font-family: $wikit-OptionsMenu-no-results-font-family;
+		font-size: $wikit-OptionsMenu-no-results-font-size;
+		font-weight: $wikit-OptionsMenu-no-results-font-weight;
+		color: $wikit-OptionsMenu-no-results-font-color;
+		line-height: $wikit-OptionsMenu-no-results-line-height;
+		padding-block: $wikit-OptionsMenu-no-results-padding-vertical;
+		padding-inline: $wikit-OptionsMenu-no-results-padding-horizontal;
 	}
 }
 </style>

--- a/vue-components/stories/OptionsMenu.stories.ts
+++ b/vue-components/stories/OptionsMenu.stories.ts
@@ -1,10 +1,10 @@
-import LookupMenu from '@/components/LookupMenu';
+import OptionsMenu from '@/components/OptionsMenu';
 import { Component } from 'vue';
 import { MenuItem } from '@/components/MenuItem';
 
 export default {
-	component: LookupMenu,
-	title: '/Lookup/LookupMenu',
+	component: OptionsMenu,
+	title: 'OptionsMenu',
 };
 
 const vegetableItems = [
@@ -56,7 +56,7 @@ const vegetableItems = [
 
 export function withItems( args: { boldLabels: boolean } ): Component {
 	return {
-		components: { LookupMenu },
+		components: { OptionsMenu },
 		computed: {
 			menuItems(): MenuItem[] {
 				return vegetableItems;
@@ -65,11 +65,11 @@ export function withItems( args: { boldLabels: boolean } ): Component {
 		props: Object.keys( args ),
 		template: `
 			<div>
-				<LookupMenu
+				<OptionsMenu
 					:menu-items="menuItems"
 					:bold-labels="boldLabels"
 				>
-				</LookupMenu>
+				</OptionsMenu>
 			</div>
 		`,
 	};
@@ -88,17 +88,17 @@ withItems.argTypes = {
 
 export function noItems(): Component {
 	return {
-		components: { LookupMenu },
+		components: { OptionsMenu },
 
 		template: `
 			<div>
-				<LookupMenu
+				<OptionsMenu
 					:menu-items="[]"
 				>
                   <template v-slot:no-results>
                     <em>Nothing</em> was found! 😢
                   </template>
-				</LookupMenu>
+				</OptionsMenu>
 			</div>
 		`,
 	};

--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -18,9 +18,9 @@ module.exports = {
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'whatever' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
-			.assert.containsText( '.wikit-LookupMenu__no-results', 'No match was found' );
+			.assert.containsText( '.wikit-OptionsMenu__no-results', 'No match was found' );
 	},
-	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
+	'Lookup Menu selects menu item when OptionsMenu-Item clicked': ( client ) => {
 		client
 			.pause( 500 )
 			.init()
@@ -29,8 +29,8 @@ module.exports = {
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'potato' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
-			.assert.visible( '.wikit-LookupMenu__item' )
-			.click( '.wikit-LookupMenu__item' )
+			.assert.visible( '.wikit-OptionsMenu__item' )
+			.click( '.wikit-OptionsMenu__item' )
 			.assert.containsText( '.selected-item-label', 'potato' )
 			.assert.containsText( '.selected-item-id', 'Q10998' );
 	},
@@ -43,7 +43,7 @@ module.exports = {
 			.waitForElementPresent( '.wikit-Lookup' )
 			.setValue( 'input', 'a' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
-			.execute( 'document.querySelectorAll(".wikit-LookupMenu__item")[7].scrollIntoView(false)' )
+			.execute( 'document.querySelectorAll(".wikit-OptionsMenu__item")[7].scrollIntoView(false)' )
 			.assert.containsText( '.first-visible-element-index', '2' )
 			.assert.containsText( '.last-visible-element-index', '7' );
 	},

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 import Lookup from '@/components/Lookup.vue';
-import LookupMenu from '@/components/LookupMenu.vue';
+import OptionsMenu from '@/components/OptionsMenu.vue';
 import Input from '@/components/Input.vue';
 import ValidationMessage from '@/components/ValidationMessage.vue';
 import { MenuItem } from '@/components/MenuItem';
@@ -107,7 +107,7 @@ describe( 'Lookup', () => {
 			},
 		} );
 
-		expect( wrapper.findComponent( LookupMenu ).isVisible() ).toBe( false );
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( false );
 	} );
 
 	it( 'shows the lookup menu if the input field is focused and has content', () => {
@@ -119,7 +119,7 @@ describe( 'Lookup', () => {
 		wrapper.findComponent( Input ).trigger( 'focus' );
 
 		return Vue.nextTick().then( () => {
-			expect( wrapper.findComponent( LookupMenu ).isVisible() ).toBe( true );
+			expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
 		} );
 	} );
 
@@ -130,7 +130,7 @@ describe( 'Lookup', () => {
 		];
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
 
-		expect( wrapper.findComponent( LookupMenu ).props( 'menuItems' ) ).toBe( menuItems );
+		expect( wrapper.findComponent( OptionsMenu ).props( 'menuItems' ) ).toBe( menuItems );
 	} );
 
 	it( 'emits an `input` event containing the selected menu item upon selection', async () => {
@@ -141,7 +141,7 @@ describe( 'Lookup', () => {
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
 
 		const selectedItem = 1;
-		wrapper.findAll( '.wikit-LookupMenu__item' ).at( selectedItem ).element.click();
+		wrapper.findAll( '.wikit-OptionsMenu__item' ).at( selectedItem ).element.click();
 
 		expect( wrapper.emitted( 'input' )![ 0 ] ).toEqual( [ menuItems[ selectedItem ] ] );
 	} );
@@ -154,7 +154,7 @@ describe( 'Lookup', () => {
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
 
 		const selectedItem = 1;
-		wrapper.findAll( '.wikit-LookupMenu__item' ).at( selectedItem ).element.click();
+		wrapper.findAll( '.wikit-OptionsMenu__item' ).at( selectedItem ).element.click();
 
 		expect( ( wrapper.emitted( 'update:searchInput' ) )![ 0 ] )
 			.toEqual( [ menuItems[ selectedItem ].label ] );
@@ -192,7 +192,7 @@ describe( 'Lookup', () => {
 			{ label: 'duck', description: 'aquatic bird' },
 		];
 
-		const highlightedItemLabelSelector = '.wikit-LookupMenu__item--selected .wikit-LookupMenu__item__label';
+		const highlightedItemLabelSelector = '.wikit-OptionsMenu__item--selected .wikit-OptionsMenu__item__label';
 
 		const wrapper = mount( Lookup, {
 			propsData: {
@@ -204,7 +204,7 @@ describe( 'Lookup', () => {
 
 		wrapper.findComponent( Input ).trigger( 'focus' );
 		await Vue.nextTick();
-		expect( wrapper.findComponent( LookupMenu ).vm.$data.selectedItemIndex ).toBe( 1 );
+		expect( wrapper.findComponent( OptionsMenu ).vm.$data.selectedItemIndex ).toBe( 1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 	} );
 
@@ -214,38 +214,38 @@ describe( 'Lookup', () => {
 			{ label: 'duck', description: 'aquatic bird' },
 		];
 
-		const highlightedItemLabelSelector = '.wikit-LookupMenu__item--selected .wikit-LookupMenu__item__label';
+		const highlightedItemLabelSelector = '.wikit-OptionsMenu__item--selected .wikit-OptionsMenu__item__label';
 
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
-		const LookupMenuWrapper = wrapper.findComponent( LookupMenu );
+		const OptionsMenuWrapper = wrapper.findComponent( OptionsMenu );
 
-		expect( LookupMenuWrapper.isVisible() ).toBe( true );
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( -1 );
+		expect( OptionsMenuWrapper.isVisible() ).toBe( true );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( -1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).exists() ).toBe( false );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( 1 );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( 1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( 1 );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( 1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
+		expect( OptionsMenuWrapper.vm.$data.selectedItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 	} );
 
@@ -257,13 +257,13 @@ describe( 'Lookup', () => {
 
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
 
-		wrapper.findComponent( LookupMenu ).setData( { selectedItemIndex: 0 } );
+		wrapper.findComponent( OptionsMenu ).setData( { selectedItemIndex: 0 } );
 		wrapper.findComponent( Input ).trigger( 'keyup', { key: 'Escape' } );
 
 		await Vue.nextTick();
 
-		expect( wrapper.findComponent( LookupMenu ).isVisible() ).toBe( false );
-		expect( wrapper.findComponent( LookupMenu ).vm.$data.selectedItemIndex ).toBe( -1 );
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( false );
+		expect( wrapper.findComponent( OptionsMenu ).vm.$data.selectedItemIndex ).toBe( -1 );
 	} );
 
 	it( 'selects an item on Tab key', async () => {
@@ -277,7 +277,7 @@ describe( 'Lookup', () => {
 
 		const selectedItemIndex = 0;
 		wrapper.find( 'input' ).setValue( userInput );
-		wrapper.findComponent( LookupMenu ).setData( { selectedItemIndex } );
+		wrapper.findComponent( OptionsMenu ).setData( { selectedItemIndex } );
 
 		wrapper.trigger( 'keydown', { key: 'Tab' } );
 
@@ -293,19 +293,19 @@ describe( 'Lookup', () => {
 		];
 
 		const wrapper = await createLookupWrapperWithExpandedMenu( menuItems );
-		const LookupMenuWrapper = wrapper.findComponent( LookupMenu );
+		const OptionsMenuWrapper = wrapper.findComponent( OptionsMenu );
 
 		wrapper.find( 'input' ).setValue( userInput );
-		LookupMenuWrapper.setData( { selectedItemIndex: 0 } );
+		OptionsMenuWrapper.setData( { selectedItemIndex: 0 } );
 
 		wrapper.trigger( 'keyup', { key: 'Enter' } );
 		await Vue.nextTick();
 
-		expect( LookupMenuWrapper.isVisible() ).toBe( false );
+		expect( OptionsMenuWrapper.isVisible() ).toBe( false );
 
 		wrapper.findComponent( Input ).trigger( 'focus' );
 		await Vue.nextTick();
-		expect( LookupMenuWrapper.isVisible() ).toBe( true );
+		expect( OptionsMenuWrapper.isVisible() ).toBe( true );
 	} );
 
 	it( 'maintains state on enter key without any item selection', async () => {
@@ -321,9 +321,9 @@ describe( 'Lookup', () => {
 
 		wrapper.findComponent( Input ).trigger( 'keyup.enter.native' );
 
-		expect( wrapper.findComponent( LookupMenu ).vm.$data.selectedItemIndex ).toBe( -1 );
+		expect( wrapper.findComponent( OptionsMenu ).vm.$data.selectedItemIndex ).toBe( -1 );
 
 		await Vue.nextTick();
-		expect( wrapper.findComponent( LookupMenu ).isVisible() ).toBe( true );
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
 	} );
 } );

--- a/vue-components/tests/unit/components/OptionsMenu.spec.ts
+++ b/vue-components/tests/unit/components/OptionsMenu.spec.ts
@@ -1,29 +1,29 @@
 import { mount } from '@vue/test-utils';
-import LookupMenu from '@/components/LookupMenu.vue';
+import OptionsMenu from '@/components/OptionsMenu.vue';
 
-describe( 'LookupMenu', () => {
+describe( 'OptionsMenu', () => {
 	it( 'displays the menu items', () => {
 		const menuItems = [
 			{ label: 'potato', description: 'root vegetable' },
 			{ label: 'duck', description: 'aquatic bird' },
 		];
-		const wrapper = mount( LookupMenu, { propsData: { menuItems } } );
-		const renderedMenuItems = wrapper.findAll( '.wikit-LookupMenu__item' );
+		const wrapper = mount( OptionsMenu, { propsData: { menuItems } } );
+		const renderedMenuItems = wrapper.findAll( '.wikit-OptionsMenu__item' );
 
 		expect( renderedMenuItems.length ).toBe( 2 );
-		expect( renderedMenuItems.at( 0 ).find( '.wikit-LookupMenu__item__label' ).text() )
+		expect( renderedMenuItems.at( 0 ).find( '.wikit-OptionsMenu__item__label' ).text() )
 			.toBe( menuItems[ 0 ].label );
-		expect( renderedMenuItems.at( 0 ).find( '.wikit-LookupMenu__item__description' ).text() )
+		expect( renderedMenuItems.at( 0 ).find( '.wikit-OptionsMenu__item__description' ).text() )
 			.toBe( menuItems[ 0 ].description );
-		expect( renderedMenuItems.at( 1 ).find( '.wikit-LookupMenu__item__label' ).text() )
+		expect( renderedMenuItems.at( 1 ).find( '.wikit-OptionsMenu__item__label' ).text() )
 			.toBe( menuItems[ 1 ].label );
-		expect( renderedMenuItems.at( 1 ).find( '.wikit-LookupMenu__item__description' ).text() )
+		expect( renderedMenuItems.at( 1 ).find( '.wikit-OptionsMenu__item__description' ).text() )
 			.toBe( menuItems[ 1 ].description );
 	} );
 
 	it( 'shows the "no match found" text if there are no menu items', () => {
 		const noResultsFoundText = 'no results. so sad.';
-		const wrapper = mount( LookupMenu, {
+		const wrapper = mount( OptionsMenu, {
 			propsData: {
 				menuItems: [],
 			},
@@ -36,7 +36,7 @@ describe( 'LookupMenu', () => {
 	} );
 
 	it( 'does not show the "no match found" text if there are menu items', () => {
-		const wrapper = mount( LookupMenu, {
+		const wrapper = mount( OptionsMenu, {
 			propsData: {
 				menuItems: [
 					{ label: 'potato', description: 'root vegetable' },
@@ -48,6 +48,6 @@ describe( 'LookupMenu', () => {
 			},
 		} );
 
-		expect( wrapper.find( '.wikit-LookupMenu__no-results' ).exists() ).toBeFalsy();
+		expect( wrapper.find( '.wikit-OptionsMenu__no-results' ).exists() ).toBeFalsy();
 	} );
 } );


### PR DESCRIPTION
Builds upon: #282 
Is followed by: #288 

That component is now generic enough to be used both by the Lookup and the Dropdown and so it should have a name that reflects this.