### PR TITLE
Ensure tokens are present before building storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "lerna bootstrap",
     "test": "lerna run test",
     "test:e2e": "lerna run e2e:saucelabs --scope @wmde/wikit-vue-components",
-    "build:storybook": "npm-run-all build:storybook:*",
+    "build:storybook": "lerna run build --scope @wmde/wikit-tokens && npm-run-all build:storybook:*",
     "build:storybook:docs": "lerna run build --scope @wmde/wikit-docs",
     "build:storybook:vue-components": "lerna run build:storybook --scope @wmde/wikit-vue-components",
     "build:storybook:extract-stories": "lerna run build:extract-stories --scope @wmde/wikit-vue-components",


### PR DESCRIPTION
This PR fixes a problem in #282 Where the tokens are not up to date with the current state of the code. This is done by ensuring that each time the storybook is built, the tokens are built as well, as a prerequisite.