### PR TITLE
[PoC] Remove init from e2e test cases

### DIFF
--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -11,20 +11,14 @@ module.exports = {
 	},
 	'Lookup Menu displays no-results text on no matches found': ( client ) => {
 		client
-			.init()
-			.openComponentStoryDirectory( 'lookup' )
-			.openComponentStory( 'lookup-lookup' )
-			.waitForElementPresent( '.wikit-Lookup' )
+			.clearValue( 'input' )
 			.setValue( 'input', 'whatever' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
 			.assert.containsText( '.wikit-LookupMenu__no-results', 'No match was found' );
 	},
 	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
 		client
-			.init()
-			.openComponentStoryDirectory( 'lookup' )
-			.openComponentStory( 'lookup-lookup' )
-			.waitForElementPresent( '.wikit-Lookup' )
+			.clearValue( 'input' )
 			.setValue( 'input', 'potato' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
 			.assert.visible( '.wikit-LookupMenu__item' )
@@ -34,10 +28,7 @@ module.exports = {
 	},
 	'Lookup emits first and last index on scroll change': ( client ) => {
 		client
-			.init()
-			.openComponentStoryDirectory( 'lookup' )
-			.openComponentStory( 'lookup-lookup' )
-			.waitForElementPresent( '.wikit-Lookup' )
+			.clearValue( 'input' )
 			.setValue( 'input', 'a' )
 			.waitForElementPresent( '.wikit-Lookup__menu' )
 			.execute( 'document.querySelectorAll(".wikit-LookupMenu__item")[7].scrollIntoView(false)' )


### PR DESCRIPTION
+ testing if we really need to init the tests before each test
removing them can potentially solve the problem of making too many
calls to chromatic