### PR TITLE
Add e2e delay

### DIFF
--- a/vue-components/tests/e2e/specs/Button.test.js
+++ b/vue-components/tests/e2e/specs/Button.test.js
@@ -1,6 +1,7 @@
 module.exports = {
 	'Button is visible': ( client ) => {
 		client
+			.pause( 500 )
 			.init()
 			.openComponentStory( 'button' )
 			.waitForElementPresent( '.wikit-Button' )

--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -22,8 +22,8 @@ module.exports = {
 	},
 	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
 		client
-			.init()
 			.pause( 500 )
+			.init()
 			.openComponentStoryDirectory( 'lookup' )
 			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )
@@ -36,8 +36,8 @@ module.exports = {
 	},
 	'Lookup emits first and last index on scroll change': ( client ) => {
 		client
-			.init()
 			.pause( 500 )
+			.init()
 			.openComponentStoryDirectory( 'lookup' )
 			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )

--- a/vue-components/tests/e2e/specs/Lookup.test.js
+++ b/vue-components/tests/e2e/specs/Lookup.test.js
@@ -11,6 +11,7 @@ module.exports = {
 	},
 	'Lookup Menu displays no-results text on no matches found': ( client ) => {
 		client
+			.pause( 500 )
 			.init()
 			.openComponentStoryDirectory( 'lookup' )
 			.openComponentStory( 'lookup-lookup' )
@@ -22,6 +23,7 @@ module.exports = {
 	'Lookup Menu selects menu item when LookupMenu-Item clicked': ( client ) => {
 		client
 			.init()
+			.pause( 500 )
 			.openComponentStoryDirectory( 'lookup' )
 			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )
@@ -35,6 +37,7 @@ module.exports = {
 	'Lookup emits first and last index on scroll change': ( client ) => {
 		client
 			.init()
+			.pause( 500 )
 			.openComponentStoryDirectory( 'lookup' )
 			.openComponentStory( 'lookup-lookup' )
 			.waitForElementPresent( '.wikit-Lookup' )


### PR DESCRIPTION
After discovering that the tests runner was causing chromatic to respond with 503 due to heavy traffic, we decided to try and add a pause between each test, to mitigate the amount of requests.