### PR TITLE
Correct value of progressive-active font color

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -156,7 +156,7 @@
                 "value": "{color.modifier.lighten.accent-50.value}"
             },
             "progressive-active": {
-                "value": "{color.accent.50.value}"
+                "value": "{color.accent.30.value}"
             },
             "destructive": {
                 "value": "{color.utility.red.50.value}"


### PR DESCRIPTION
The value of font-color-progressive-active should be Accent 30 instead of Accent 50.

This is not a dejà vu. I failed to actually replace the color value in the original PR (#272). I only had one job :facepalm: