### PR TITLE
Add Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ development)_
 - Initial version of the Lookup component
 - Additional icons to the Icon component
 - New tokens based on wikimedia-ui-base v 0.18.0
+- New Dropdown Component
 
 ### Removed
 

--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -1,0 +1,228 @@
+<template>
+	<div
+		:class="[ 'wikit', 'wikit-Dropdown' ]"
+		@keydown="triggerKeyDown"
+	>
+		<label
+			class="wikit-Dropdown__label"
+			@click="$refs.select.focus()"
+		>{{ label }}</label>
+		<div
+			class="wikit-Dropdown__select"
+			:tabindex="!disabled && '0'"
+			:disabled="disabled"
+			@click="onClick"
+			@blur="showMenu = false"
+			ref="select"
+		>
+			<span
+				class="wikit-Dropdown__selectedOption"
+				v-if="value"
+			>{{ value.label }}</span>
+			<span
+				class="wikit-Dropdown__placeholder"
+				v-else
+			>{{ placeholder }}</span>
+			<svg
+				class="wikit-Dropdown__arrow"
+				fill="none"
+				viewBox="0 0 12 12"
+				xmlns="http://www.w3.org/2000/svg"
+			><path fill="currentColor" d="M6 10L12 3.94231L11 3L6 7.98077L1 3L5.2958e-07 3.94231L6 10Z" /></svg>
+		</div>
+		<OptionsMenu
+			class="wikit-Dropdown__menu"
+			:menu-items="menuItems"
+			:selected-item-index="selectedItemIndex"
+			v-show="showMenu"
+			@select="onSelect"
+			@esc="onEsc"
+			ref="menu"
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType, VueConstructor } from 'vue';
+import { MenuItem } from '@/components/MenuItem';
+import OptionsMenu from '@/components/OptionsMenu.vue';
+import isEqual from 'lodash.isequal';
+
+export default ( Vue as VueConstructor<Vue & { $refs: {
+	menu: InstanceType<typeof OptionsMenu>;
+	select: HTMLElement;
+}; }> ).extend( {
+	name: 'Dropdown',
+	data() {
+		return {
+			showMenu: false,
+		};
+	},
+	props: {
+		menuItems: {
+			type: Array as PropType<MenuItem[]>,
+			default: (): [] => [],
+		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+		label: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * The selected menu item, can be of type `MenuItem` or `null`.
+		 *
+		 * The data usually comes from the consumer's `v-model` annotation on the Lookup component.
+		 */
+		value: {
+			type: Object,
+			default: null,
+		},
+		placeholder: {
+			type: String,
+			default: '',
+		},
+	},
+	computed: {
+		selectedItemIndex(): number {
+			if ( this.value === null || this.menuItems.length === 0 ) {
+				return -1;
+			}
+
+			return this.menuItems.findIndex(
+				( menuItem ) => { return isEqual( menuItem, this.value ); },
+				this,
+			);
+		},
+	},
+	methods: {
+		triggerKeyDown( event: KeyboardEvent ): void {
+			switch ( event.key ) {
+				case 'Enter':
+					if ( !this.showMenu ) {
+						this.startShowingTheMenu();
+						return;
+					}
+					break;
+				case 'ArrowDown':
+					this.startShowingTheMenu();
+			}
+			this.$refs.menu.onKeyDown( event );
+		},
+		async startShowingTheMenu(): Promise<void> {
+			this.showMenu = true;
+			await this.$nextTick();
+			this.$refs.menu.resizeMenu();
+		},
+		onEsc(): void {
+			this.showMenu = false;
+		},
+
+		onSelect( menuItem: MenuItem ): void {
+			this.showMenu = false;
+
+			// the following comment generates the event's description for the docs tab in storybook
+			/**
+			 * This event is emitted whenever an item is selected on the Dropdown.
+			 *
+			 * @property {MenuItem|null} The event payload contains the whole MenuItem object.
+			 *                           The payload is null when no item is selected or the item is deselected.
+			 */
+			this.$emit( 'input', menuItem );
+		},
+		onClick(): void {
+			this.startShowingTheMenu();
+		},
+	},
+	components: {
+		OptionsMenu,
+	},
+} );
+</script>
+
+<style lang="scss">
+$base: '.wikit-Dropdown';
+
+#{$base} {
+	position: relative;
+
+	&__select {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		border-width: $wikit-Dropdown-border-width;
+		border-color: $wikit-Dropdown-border-color;
+		border-radius: $wikit-Dropdown-border-radius;
+		border-style: $wikit-Dropdown-border-style;
+		box-sizing: border-box;
+		padding-inline: $wikit-Dropdown-desktop-padding-inline;
+		padding-block: $wikit-Dropdown-desktop-padding-block;
+		@media (max-width: $width-breakpoint-mobile) {
+			padding-inline: $wikit-Dropdown-mobile-padding-inline;
+			padding-block: $wikit-Dropdown-mobile-padding-block;
+		}
+
+		cursor: pointer;
+		background-color: $wikit-Dropdown-background-color;
+		transition-duration: $wikit-Dropdown-transition-duration;
+		transition-timing-function: $wikit-Dropdown-transition-timing-function;
+		transition-property: $wikit-Dropdown-transition-property;
+
+		&[disabled] {
+			background-color: $wikit-Dropdown-disabled-background-color;
+			border-color: $wikit-Dropdown-disabled-border-color;
+			pointer-events: none;
+
+			#{$base}__placeholder,
+			#{$base}__selectedOption,
+			#{$base}__arrow {
+				color: $wikit-Dropdown-disabled-color;
+			}
+		}
+
+		&:hover {
+			border-color: $wikit-Dropdown-hover-border-color;
+			background-color: $wikit-Dropdown-hover-background-color;
+		}
+
+		&:focus,
+		&:active {
+			border-color: $wikit-Dropdown-active-border-color;
+			background-color: $wikit-Dropdown-active-background-color;
+			box-shadow: $wikit-Dropdown-active-box-shadow;
+		}
+	}
+
+	&__arrow {
+		height: $wikit-Dropdown-icon-expand-size;
+	}
+
+	&__selectedOption {
+		line-height: $wikit-Dropdown-selected-option-line-height;
+		font-family: $wikit-Dropdown-selected-option-font-family;
+		font-size: $wikit-Dropdown-selected-option-font-size;
+		font-weight: $wikit-Dropdown-selected-option-font-weight;
+		color: $wikit-Dropdown-selected-option-color;
+	}
+
+	&__placeholder {
+		color: $wikit-Dropdown-placeholder-color;
+		line-height: $wikit-Dropdown-placeholder-line-height;
+		font-family: $wikit-Dropdown-placeholder-font-family;
+		font-size: $wikit-Dropdown-placeholder-font-size;
+		font-weight: $wikit-Dropdown-placeholder-font-weight;
+	}
+
+	&__menu {
+		position: absolute;
+	}
+
+	&__label {
+		@include Label;
+		display: block;
+	}
+}
+</style>

--- a/vue-components/src/main.ts
+++ b/vue-components/src/main.ts
@@ -1,10 +1,12 @@
 import Button from './components/Button.vue';
 import TextInput from './components/TextInput.vue';
 import Lookup from './components/Lookup.vue';
+import Dropdown from './components/Dropdown.vue';
 import Message from './components/Message.vue';
 
 export {
 	Button,
+	Dropdown,
 	TextInput,
 	Lookup,
 	Message,

--- a/vue-components/stories/Dropdown.stories.ts
+++ b/vue-components/stories/Dropdown.stories.ts
@@ -1,0 +1,86 @@
+import Dropdown from '@/components/Dropdown';
+import { Component } from 'vue';
+import { MenuItem } from '@/components/MenuItem';
+
+export default {
+	component: Dropdown,
+	title: 'Dropdown',
+};
+
+const menuItems: MenuItem[] = [
+	{
+		label: 'matching',
+		value: 'matching',
+	},
+	{
+		label: 'regardless of value',
+		value: 'any',
+	},
+	{
+		label: 'without',
+		value: 'without',
+	},
+	{
+		label: 'less than',
+		value: 'less than',
+	},
+	{
+		label: 'more than',
+		value: 'more than',
+	},
+	{
+		label: 'earlier than',
+		value: 'earlier',
+	},
+	{
+		label: 'later than',
+		value: 'later',
+	},
+];
+
+export function basic( args ): Component {
+	return {
+		components: { Dropdown },
+		data(): unknown {
+			return {
+				selectedItem: null,
+			};
+		},
+		props: Object.keys( args ),
+		template: `
+			<div><div style="max-width: 512px">
+				<Dropdown
+					:label="label"
+					:menu-items="menuItems"
+					v-model="selectedItem"
+					:placeholder="placeholder"
+					:disabled="disabled"
+				/>
+				<div v-if="selectedItem" style="margin-top: 16px">
+					Selected Option:
+					<span class="selected-item-label">{{ selectedItem.label }}</span>
+					(<span class="selected-item-id">{{ selectedItem.value }}</span>)
+				</div>
+			</div></div>
+		`,
+	};
+}
+
+basic.args = {
+	disabled: false,
+	label: 'Label',
+	placeholder: 'Select an option',
+	menuItems,
+};
+basic.argTypes = {
+	menuItems: {
+		control: {
+			disable: true,
+		},
+	},
+	value: {
+		control: {
+			disable: true,
+		},
+	},
+};

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -1,0 +1,238 @@
+import Vue from 'vue';
+import { mount, Wrapper } from '@vue/test-utils';
+import Dropdown from '@/components/Dropdown.vue';
+import OptionsMenu from '@/components/OptionsMenu.vue';
+import { MenuItem } from '@/components/MenuItem';
+
+async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[] ): Promise<Wrapper<Dropdown>> {
+	const wrapper = mount( Dropdown, { propsData: {
+		menuItems,
+	} } );
+	wrapper.find( '.wikit-Dropdown__select' ).trigger( 'click' );
+
+	await Vue.nextTick();
+	return wrapper;
+}
+
+describe( 'Dropdown', () => {
+
+	it( 'has a label', () => {
+		const label = 'a label';
+		const wrapper = mount( Dropdown, {
+			propsData: {
+				label,
+			},
+		} );
+
+		expect( wrapper.find( '.wikit-Dropdown__label' ).text() ).toBe( label );
+	} );
+
+	it( 'can be disabled', () => {
+		const wrapper = mount( Dropdown, {
+			propsData: {
+				disabled: true,
+			},
+		} );
+
+		expect( wrapper.find( '.wikit-Dropdown__select' ).attributes( 'disabled' ) ).toBe( 'disabled' );
+	} );
+
+	it( 'can have a placeholder', () => {
+		const placeholder = 'a placeholder';
+		const wrapper = mount( Dropdown, {
+			propsData: {
+				placeholder,
+			},
+		} );
+
+		expect( wrapper.text() ).toBe( placeholder );
+	} );
+
+	it( 'does not show the Dropdown menu if the select field is not focused', () => {
+		const wrapper = mount( Dropdown, {
+			propsData: {
+				menuItems: [ { label: 'potato', description: 'root vegetable' } ],
+			},
+		} );
+
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( false );
+	} );
+
+	it( 'shows the Dropdown menu on click', async () => {
+		const wrapper = mount( Dropdown );
+		wrapper.find( '.wikit-Dropdown__select' ).trigger( 'click' );
+
+		await Vue.nextTick();
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
+	} );
+
+	it( 'shows the Dropdown menu on pressing Enter', async () => {
+		const wrapper = mount( Dropdown );
+		wrapper.trigger( 'keydown', { key: 'Enter' } );
+
+		await Vue.nextTick();
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
+	} );
+
+	it( 'shows the Dropdown menu on pressing Arrow-down', async () => {
+		const wrapper = mount( Dropdown );
+		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+
+		await Vue.nextTick();
+		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
+	} );
+
+	it( 'shows the menu items that are passed as props', async () => {
+		const menuItems = [
+			{ label: 'potato', description: 'root vegetable' },
+			{ label: 'duck', description: 'aquatic bird' },
+		];
+		const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+
+		expect( wrapper.findComponent( OptionsMenu ).props( 'menuItems' ) ).toBe( menuItems );
+	} );
+
+	it( 'emits an `input` event containing the selected menu item upon selection', async () => {
+		const menuItems = [
+			{ label: 'potato', description: 'root vegetable' },
+			{ label: 'duck', description: 'aquatic bird' },
+		];
+		const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+
+		const selectedItem = 1;
+		wrapper.findAll( '.wikit-OptionsMenu__item' ).at( selectedItem ).element.click();
+
+		expect( wrapper.emitted( 'input' )![ 0 ] ).toEqual( [ menuItems[ selectedItem ] ] );
+	} );
+
+	it( 'shows the currently selected menu item after reopening it', async () => {
+		const menuItems = [
+			{ label: 'potato', description: 'root vegetable' },
+			{ label: 'duck', description: 'aquatic bird' },
+		];
+
+		const selectedItemLabelSelector = '.wikit-OptionsMenu__item--selected .wikit-OptionsMenu__item__label';
+
+		const wrapper = mount( Dropdown, {
+			propsData: {
+				value: { label: 'duck', description: 'aquatic bird' },
+				menuItems,
+			},
+		} );
+
+		wrapper.find( '.wikit-Dropdown__select' ).trigger( 'click' );
+		await Vue.nextTick();
+		expect( wrapper.findComponent( OptionsMenu ).props().selectedItemIndex ).toBe( 1 );
+		expect( wrapper.find( selectedItemLabelSelector ).text() ).toBe( 'duck' );
+	} );
+
+	describe( 'Dropdown menu keyboard navigation', () => {
+		it( 'allows navigation with the up and down arrow keys', async () => {
+			const menuItems = [
+				{ label: 'potato', description: 'root vegetable' },
+				{ label: 'duck', description: 'aquatic bird' },
+			];
+
+			const highlightedItemLabelSelector = '.wikit-OptionsMenu__item--hovered .wikit-OptionsMenu__item__label';
+
+			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+			const OptionsMenuWrapper = wrapper.findComponent( OptionsMenu );
+
+			expect( OptionsMenuWrapper.isVisible() ).toBe( true );
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
+			expect( wrapper.find( highlightedItemLabelSelector ).exists() ).toBe( false );
+
+			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			await Vue.nextTick();
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
+			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
+
+			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			await Vue.nextTick();
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
+			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
+
+			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			await Vue.nextTick();
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
+			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
+
+			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
+			await Vue.nextTick();
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
+			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
+
+			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
+			await Vue.nextTick();
+			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
+			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
+		} );
+
+		it( 'closes the menu on Esc key', async () => {
+			const menuItems = [
+				{ label: 'potato', description: 'root vegetable' },
+				{ label: 'duck', description: 'aquatic bird' },
+			];
+
+			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+
+			wrapper.findComponent( OptionsMenu ).setData( { keyboardHoveredItemIndex: 0 } );
+			wrapper.trigger( 'keydown', { key: 'Escape' } );
+
+			await Vue.nextTick();
+
+			expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( false );
+			expect( wrapper.findComponent( OptionsMenu ).vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
+		} );
+
+		it( 'selects an item on Tab key', async () => {
+			const menuItems = [
+				{ label: 'potato', description: 'root vegetable' },
+				{ label: 'duck', description: 'aquatic bird' },
+			];
+
+			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+
+			const keyboardHoveredItemIndex = 0;
+			wrapper.findComponent( OptionsMenu ).setData( { keyboardHoveredItemIndex } );
+
+			wrapper.trigger( 'keydown', { key: 'Tab' } );
+
+			expect( wrapper.emitted( 'input' )!.pop() ).toStrictEqual( [ menuItems[ keyboardHoveredItemIndex ] ] );
+		} );
+
+		it( 'selects an item on enter key', async () => {
+			const menuItems = [
+				{ label: 'potato', description: 'root vegetable' },
+				{ label: 'duck', description: 'aquatic bird' },
+			];
+
+			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+			const OptionsMenuWrapper = wrapper.findComponent( OptionsMenu );
+
+			const keyboardHoveredItemIndex = 0;
+			OptionsMenuWrapper.setData( { keyboardHoveredItemIndex } );
+
+			wrapper.trigger( 'keydown', { key: 'Enter' } );
+			await Vue.nextTick();
+
+			expect( OptionsMenuWrapper.isVisible() ).toBe( false );
+			expect( wrapper.emitted( 'input' )!.pop() ).toStrictEqual( [ menuItems[ keyboardHoveredItemIndex ] ] );
+		} );
+
+		it( 'maintains state on enter key without any item selection', async () => {
+			const menuItems = [
+				{ label: 'potato', description: 'root vegetable' },
+				{ label: 'duck', description: 'aquatic bird' },
+			];
+
+			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+			wrapper.trigger( 'keydown', { key: 'Enter' } );
+
+			expect( wrapper.findComponent( OptionsMenu ).vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
+
+			await Vue.nextTick();
+			expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
The `<label>` does not seem to natively focus non-form elements even if they have a `tabindex >= 0` (at least on Firefox), so this is done explicitly via a click event.

The SVG of the small arrow is added inline for now. This allows us to style it with CSS, which wouldn't be possible if we were to use it via background-image. It can be extract if and when we need to use it somewhere else as well. It was not added to the Icon component as that component explicitly sets a color instead of allowing the usage of the current text color.

The scroll events are ignored as a Dropdown always has all its possible options available.

The validation message will be added in another commit.

Bug: [T266545](https://phabricator.wikimedia.org/T266545)