### PR TITLE
Extract validation message logic with composition

### DIFF
--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -6328,6 +6328,21 @@
 				}
 			}
 		},
+		"@vue/composition-api": {
+			"version": "1.0.0-beta.20",
+			"resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-beta.20.tgz",
+			"integrity": "sha512-Lpaxt9+3cy97QJoCJ81qNe6TeGg092iHtqilKdbE5NapHqoSwiuYUSHX2ANIaO+C1Q1J7bITv1/saLUMNuwQOg==",
+			"requires": {
+				"tslib": "^2.0.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+				}
+			}
+		},
 		"@vue/eslint-config-standard": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@vue/eslint-config-standard/-/eslint-config-standard-5.1.2.tgz",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -33,6 +33,7 @@
   ],
   "types": "dist/main.d.ts",
   "dependencies": {
+    "@vue/composition-api": "^1.0.0-beta.20",
     "@wmde/wikit-tokens": "^2.0.0-alpha.0",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",

--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -19,28 +19,28 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import VueCompositionAPI, { defineComponent, computed } from '@vue/composition-api';
 import ValidationMessage from './ValidationMessage.vue';
 import Input from './Input.vue';
 import generateUid from '@/components/util/generateUid';
+import { errorProp, ErrorProp, getFeedbackTypeFromProps } from '@/compositions/validatable';
+
+Vue.use( VueCompositionAPI );
 
 /**
  * Text input fields are form elements that let users input and edit values in the form of text.
  *
  * Uses the following components internally: Input, ValidationMessage
  */
-export default Vue.extend( {
+export default defineComponent( {
 	name: 'TextInput',
+	setup( props: { error: ErrorProp } ) {
+		return {
+			feedbackType: computed( getFeedbackTypeFromProps( props ) ),
+		};
+	},
 	props: {
-		error: {
-			type: Object,
-			validator( error: { type?: string; message?: string } ): boolean {
-				return error === null ||
-					typeof error.message === 'string' &&
-					typeof error.type === 'string' &&
-					[ 'warning', 'error' ].includes( error.type );
-			},
-			default: null,
-		},
+		error: errorProp,
 		disabled: {
 			type: Boolean,
 			default: false,
@@ -72,12 +72,6 @@ export default Vue.extend( {
 			 * contains user input, i.e. the contents of the input value
 			 */
 			this.$emit( 'input', value );
-		},
-	},
-
-	computed: {
-		feedbackType(): string|null {
-			return this.error && this.error.type || null;
 		},
 	},
 

--- a/vue-components/src/compositions/validatable.ts
+++ b/vue-components/src/compositions/validatable.ts
@@ -1,0 +1,26 @@
+import { PropType } from '@vue/composition-api';
+
+function getFeedbackTypeFromProps( props: { error: ErrorProp } ): () => string|null {
+	return () => {
+		return props.error && props.error.type || null;
+	};
+}
+
+interface ErrorProp { type?: 'error'|'warning'; message?: string }
+
+const errorProp = {
+	type: Object as PropType<ErrorProp>,
+	validator( error: ErrorProp ): boolean {
+		return error === null ||
+			typeof error.message === 'string' &&
+			typeof error.type === 'string' &&
+			[ 'warning', 'error' ].includes( error.type );
+	},
+	default: null,
+};
+
+export {
+	getFeedbackTypeFromProps,
+	errorProp,
+	ErrorProp,
+};

--- a/vue-components/tests/unit/compositions/validateable.ts
+++ b/vue-components/tests/unit/compositions/validateable.ts
@@ -1,0 +1,29 @@
+import { getFeedbackTypeFromProps, errorProp } from '@/compositions/validatable';
+
+describe( 'validatable composition', () => {
+	it( 'gets the feedback type from an error prop', () => {
+		const feedbackType = 'warning' as const;
+		const testProps = {
+			error: {
+				type: feedbackType,
+				messsage: 'something',
+			},
+		};
+
+		expect( getFeedbackTypeFromProps( testProps ) ).toBe( feedbackType );
+	} );
+
+	describe( 'error prop validation', () => {
+		it( 'accepts "warning" error type', () => {
+			expect( errorProp.validator( { type: 'warning' } ) ).toBe( true );
+		} );
+
+		it( 'accepts "error" error type', () => {
+			expect( errorProp.validator( { type: 'error' } ) ).toBe( true );
+		} );
+
+		it( 'disallows other error types', () => {
+			expect( errorProp.validator( { type: 'notice' } ) ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
With these being the first meaningful case of code-reuse, it is a good moment to introduce the vue3 composition api via a plugin to this vue2 library.

To get the type inference for the setup option, we have to use the defineComponent function for creating our components. This has the side-effect that we have to rethink how to type the menu ref. The solution was to move this into the setup function as well because there we can use the vue3 way of accessing and _typing_ refs.


The actual validation message will be added to the Dropdown component in a follow-up pull request.

Todo:
- [x] Figure out typing of $refs
- [x] move and rename extracted code to something like `compositions/validateable.ts`
- [x] add tests for extracted methods!

Bug: [T266546](https://phabricator.wikimedia.org/T266546)