### PR TITLE
Add Error and Warning state to Dropdown

### DIFF
--- a/vue-components/stories/Dropdown.stories.ts
+++ b/vue-components/stories/Dropdown.stories.ts
@@ -31,10 +31,12 @@ const menuItems: MenuItem[] = [
 	{
 		label: 'earlier than',
 		value: 'earlier',
+		tag: 'has error',
 	},
 	{
 		label: 'later than',
 		value: 'later',
+		tag: 'has warning',
 	},
 ];
 
@@ -46,6 +48,17 @@ export function basic( args ): Component {
 				selectedItem: null,
 			};
 		},
+		computed: {
+			error(): any {
+				if ( this.selectedItem?.value === 'later' ) {
+					return { type: 'warning', message: 'Warning to be careful 🚧' };
+				}
+				if ( this.selectedItem?.value === 'earlier' ) {
+					return { type: 'error', message: 'There was an error 😕' };
+				}
+				return null;
+			},
+		},
 		props: Object.keys( args ),
 		template: `
 			<div><div style="max-width: 512px">
@@ -55,6 +68,7 @@ export function basic( args ): Component {
 					v-model="selectedItem"
 					:placeholder="placeholder"
 					:disabled="disabled"
+					:error="error"
 				/>
 				<div v-if="selectedItem" style="margin-top: 16px">
 					Selected Option:

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 import Dropdown from '@/components/Dropdown.vue';
 import OptionsMenu from '@/components/OptionsMenu.vue';
+import ValidationMessage from '@/components/ValidationMessage.vue';
 import { MenuItem } from '@/components/MenuItem';
 
 async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[] ): Promise<Wrapper<Dropdown>> {
@@ -233,6 +234,60 @@ describe( 'Dropdown', () => {
 
 			await Vue.nextTick();
 			expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
+		} );
+	} );
+
+	describe( 'with Errors', () => {
+
+		it( 'rejects errors without a message', () => {
+			expect( () => mount( Dropdown, {
+				propsData: {
+					error: {
+						type: 'warning',
+					},
+				},
+			} ) ).toThrow();
+		} );
+
+		it( 'rejects errors without a type', () => {
+			expect( () => mount( Dropdown, {
+				propsData: {
+					error: {
+						message: 'things went wrong',
+					},
+				},
+			} ) ).toThrow();
+		} );
+
+		it( 'rejects invalid error types', () => {
+			expect( () => mount( Dropdown, {
+				propsData: {
+					error: {
+						type: 'not-that-bad',
+						message: 'a valid message',
+					},
+				},
+			} ) ).toThrow();
+		} );
+
+		it.each( [
+			'warning',
+			'error',
+		] )( 'passes the error to the ValidationMessage child component', ( errorType ) => {
+			const errorMessage = 'error!!!!';
+			const wrapper = mount( Dropdown, {
+				propsData: {
+					error: {
+						type: errorType,
+						message: errorMessage,
+					},
+				},
+			} );
+			const validationMessage = wrapper.findComponent( ValidationMessage );
+
+			expect( validationMessage.props( 'message' ) ).toBe( errorMessage );
+			expect( validationMessage.props( 'type' ) ).toBe( errorType );
+			expect( validationMessage.isVisible() ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
The `menuItems` `PropType` is removed from the prop definition as it seems to be completely ignored. However, the menuItem prop must be defined in the signature of the setup function even if it is not used inside the setup function to receive typing in the computed methods added via the usual options API.

Bug: T266546