### PR TITLE
fix dropdown spacing

### DIFF
--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -198,6 +198,7 @@ $base: '.wikit-Dropdown';
 
 	&__arrow {
 		height: $wikit-Dropdown-icon-expand-size;
+		margin-left: $wikit-Dropdown-icon-expand-spacing-horizontal;
 	}
 
 	&__selectedOption {

--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -198,7 +198,7 @@ $base: '.wikit-Dropdown';
 
 	&__arrow {
 		height: $wikit-Dropdown-icon-expand-size;
-		margin-left: $wikit-Dropdown-icon-expand-spacing-horizontal;
+		margin-inline-start: $wikit-Dropdown-icon-expand-spacing-horizontal;
 	}
 
 	&__selectedOption {


### PR DESCRIPTION
This adds a 12px margin to the left of the expand icon so it's properly separated from the dropdown label.

TBD whether it would be necessary to apply `white-space: nowrap` to the dropdown text in order to prevent unwanted wrapping after this change.