### PR TITLE
[WiP] Added slot and prop for icons in Button component

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -1,6 +1,11 @@
 <template>
-	<button :class="[ 'wikit', 'wikit-Button', `wikit-Button--${ type }` ]">
-		<slot />
+	<button :class="[ 'wikit', 'wikit-Button', `wikit-Button--${ type }`, iconOnly ? `wikit-Button--iconOnly` : '' ]">
+		<span v-if="$slots.icon" class="wikit-Button__icon">
+			<slot name="icon" />
+		</span><!--
+		--><span class="wikit-Button__label">
+			<slot />
+		</span>
 	</button>
 </template>
 
@@ -33,6 +38,10 @@ export default Vue.extend( {
 			},
 			default: 'neutral',
 		},
+		iconOnly: {
+			type: Boolean,
+			default: false,
+		},
 	},
 } );
 </script>
@@ -60,6 +69,12 @@ $base: '.wikit-Button';
 	@media (max-width: $width-breakpoint-mobile) {
 		padding-inline: $wikit-Button-large-padding-horizontal;
 		padding-block: $wikit-Button-large-padding-vertical;
+	}
+
+	&:not( #{$base}--iconOnly) &__icon {
+		padding-inline-end: $dimension-spacing-small;
+		//TODO: replace later with $wikit-Button-icon-gap;
+		//when https://github.com/wmde/wikit/pull/321 is merged
 	}
 
 	&:not(:disabled) {

--- a/vue-components/stories/Button.stories.ts
+++ b/vue-components/stories/Button.stories.ts
@@ -1,4 +1,5 @@
 import Button from '@/components/Button';
+import Icon from '@/components/Icon';
 import { Component } from 'vue';
 
 export default {
@@ -8,15 +9,31 @@ export default {
 
 export function normal(): Component {
 	return {
-		components: { Button },
+		components: { Button, Icon },
 		// The normal button types are all in the same story to achieve high % of visual tests coverage.
 		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
 		template: `
 			<div>
-				<Button type="neutral">Neutral</Button>
-				<Button type="primaryProgressive">Primary progressive</Button>
-				<Button type="primaryDestructive">Primary destructive</Button>
-				<Button disabled="true">Disabled</Button>
+				<div>
+					<Button type="neutral">Neutral</Button>
+					<Button type="primaryProgressive">Primary progressive</Button>
+					<Button type="primaryDestructive">Primary destructive</Button>
+					<Button disabled="true">Disabled</Button>
+				</div>
+				<div>
+					<h4>With icons</h4>
+					<Button type="neutral">
+						<template v-slot:icon>
+							<Icon type="info" size="medium" />
+						</template>
+						Neutral with Icon
+					</Button>
+					<Button iconOnly type="primaryProgressive" aria-label="Icon only Button">
+						<template v-slot:icon>
+							<Icon type="info" size="medium" color="white" />
+						</template>
+					</Button>
+				</div>
 			</div>
 		`,
 	};


### PR DESCRIPTION
- Add named slot to the Button component
- both slots should be wrapped in <span> with classes
- add prop "iconOnly" to Button, defaulting to false
- add a button with an icon and a label to storybook
- add a button with "iconOnly=true" to storybook