### PR TITLE
Use netlify for branch hosting the docs storybook

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Test
       run: npm run test
 
-  deploy:
+  ui-review:
     runs-on: ubuntu-latest
     needs: setup
     if: ${{ needs.setup.outputs.visual == 'true' || github.ref == 'refs/heads/master' }}
@@ -105,9 +105,36 @@ jobs:
     - name: Deploy Storybook
       run: npm run chromatic
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Restore dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          */node_modules
+        key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/package.json') }}
+    - name: Build Project
+      run: npm run build:storybook
+    - name: Deploy to netlify
+      run: echo "DEPLOY_URL=$(npx -p netlify-cli netlify deploy --dir=docs/dist --json | jq '.deploy_url' --raw-output)" >> $GITHUB_ENV
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+    - name: Print deploy URL
+      run: echo $DEPLOY_URL
+
   browser-tests:
     runs-on: ubuntu-latest
-    needs: [setup, deploy]
+    needs: [setup, ui-review]
     if: ${{ needs.setup.outputs.behavioral == 'true' || github.ref == 'refs/heads/master' }}
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR finally brings back branch hosting for the composed (tokens+docs+vue-components) storybook :tada: 

I haven't found a good way/place to show the netlify link. I added a "Print deploy URL" step in the `deploy` job, which may be good enough for now? `netlify-cli` advertises an `--alias` flag for predictable deployment URLs which looks like a good option to create deployments on a per-branch instead of a per-commit basis so that it can be permanently attached to a PR, but I didn't want to recreate [past problems](https://phabricator.wikimedia.org/T262270) by building the branch name into the URL.

Bug: [T261650](https://phabricator.wikimedia.org/T261650)