### PR TITLE
vue-components: remove confusing comment

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -27,7 +27,6 @@ export default Vue.extend( {
 		 */
 		type: {
 			type: String,
-			// TODO why does the shorter version cause problems with doc-gen?
 			validator( value: string ): boolean {
 				return [ 'neutral', 'primaryProgressive', 'primaryDestructive' ].includes( value );
 			},


### PR DESCRIPTION
This referred to an attempt at using the shorter
`Array.prototype.includes.bind( [ 'neutral', 'primaryProgressive', 'primaryDestructive' ] )`
which caused problems at build time. 