### PR TITLE
Restructure Button props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ development)_
 - New icon called trash
 - New info-outline Icon type
 
+### Changed
+- _**(Breaking)**_ the prop of the Button has been split into two: `type` and `variant`
+
 ### Removed
 
 - _**(Breaking)**_ Width property is removed from all components

--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -1,11 +1,14 @@
 <template>
-	<button :class="[ 'wikit', 'wikit-Button', `wikit-Button--${ type }` ]">
+	<button :class="[ 'wikit', 'wikit-Button', `wikit-Button--${ type }`, `wikit-Button--${ variant }` ]">
 		<slot />
 	</button>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import VueCompositionAPI, { defineComponent, onMounted } from '@vue/composition-api';
+
+Vue.use( VueCompositionAPI );
 
 /* eslint-disable no-trailing-spaces */
 /**
@@ -19,19 +22,49 @@ import Vue from 'vue';
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1581369#c5
  */
 /* eslint-enable no-trailing-spaces */
-export default Vue.extend( {
+export default defineComponent( {
 	name: 'Button',
 	props: {
 		/**
 		 * The type of the button
+		 *
+		 * Allowed values: `neutral`, `progressive`, `destructive`
 		 */
 		type: {
 			type: String,
 			validator( value: string ): boolean {
-				return [ 'neutral', 'primaryProgressive', 'primaryDestructive' ].includes( value );
+				return [ 'neutral', 'progressive', 'destructive' ].includes( value );
 			},
 			default: 'neutral',
 		},
+		/**
+		 * The variant of the button
+		 *
+		 * Allowed values: `normal`, `primary`
+		 */
+		variant: {
+			type: String,
+			validator( value: string ): boolean {
+				return [ 'normal', 'primary' ].includes( value );
+			},
+			default: 'normal',
+		},
+	},
+	setup( props: {
+		type: 'neutral'|'progressive'|'destructive';
+		variant: 'normal'|'primary';
+	} ) {
+		onMounted( () => {
+			const supportedCombinations = {
+				normal: [ 'neutral' ],
+				primary: [ 'progressive', 'destructive' ],
+			};
+			if ( !supportedCombinations[ props.variant ].includes( props.type ) ) {
+				throw new Error(
+					`The combination of variant "${props.variant}" and type "${props.type}" is not yet supported!`,
+				);
+			}
+		} );
 	},
 } );
 </script>
@@ -61,7 +94,7 @@ $base: '.wikit-Button';
 		padding-block: $wikit-Button-large-padding-vertical;
 	}
 
-	&:not(:disabled) {
+	&#{$base}--normal {
 		&#{$base}--neutral {
 			color: $wikit-Button-normal-neutral-color;
 			background-color: $wikit-Button-normal-neutral-background-color;
@@ -78,7 +111,6 @@ $base: '.wikit-Button';
 				background-color: $wikit-Button-normal-neutral-active-background-color;
 				border-color: $wikit-Button-normal-neutral-active-border-color;
 			}
-
 			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
 			&:focus:not(:active) {
 				color: $wikit-Button-normal-neutral-focus-color;
@@ -87,8 +119,10 @@ $base: '.wikit-Button';
 				box-shadow: $wikit-Button-normal-neutral-focus-box-shadow;
 			}
 		}
+	}
 
-		&#{$base}--primaryProgressive {
+	&#{$base}--primary {
+		&#{$base}--progressive {
 			color: $wikit-Button-primary-color;
 			background-color: $wikit-Button-primary-progressive-background-color;
 			border-color: $wikit-Button-primary-progressive-border-color;
@@ -111,7 +145,7 @@ $base: '.wikit-Button';
 			}
 		}
 
-		&#{$base}--primaryDestructive {
+		&#{$base}--destructive {
 			color: $wikit-Button-primary-color;
 			background-color: $wikit-Button-primary-destructive-background-color;
 			border-color: $wikit-Button-primary-destructive-border-color;
@@ -135,11 +169,13 @@ $base: '.wikit-Button';
 		}
 	}
 
-	&:disabled {
+	&#{$base}--normal:disabled,
+	&#{$base}--primary:disabled {
 		color: $wikit-Button-normal-disabled-color;
 		background-color: $wikit-Button-normal-disabled-background-color;
 		border-color: $wikit-Button-normal-disabled-border-color;
 		cursor: default;
+		pointer-events: none;
 	}
 
 	// should ideally be taken care of by the globally applied style reset (ress)

--- a/vue-components/stories/Button.stories.ts
+++ b/vue-components/stories/Button.stories.ts
@@ -13,10 +13,23 @@ export function normal(): Component {
 		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
 		template: `
 			<div>
-				<Button type="neutral">Neutral</Button>
-				<Button type="primaryProgressive">Primary progressive</Button>
-				<Button type="primaryDestructive">Primary destructive</Button>
-				<Button disabled="true">Disabled</Button>
+				<Button type="neutral" variant="normal">Neutral</Button>
+				<Button type="neutral" variant="normal" disabled="true">Disabled</Button>
+			</div>
+		`,
+	};
+}
+
+export function primary(): Component {
+	return {
+		components: { Button },
+		// The normal button types are all in the same story to achieve high % of visual tests coverage.
+		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
+		template: `
+			<div>
+				<Button type="progressive" variant="primary">Primary progressive</Button>
+				<Button type="destructive" variant="primary">Primary destructive</Button>
+				<Button type="progressive" variant="primary" disabled="true">Disabled</Button>
 			</div>
 		`,
 	};

--- a/vue-components/tests/unit/components/Button.spec.ts
+++ b/vue-components/tests/unit/components/Button.spec.ts
@@ -12,12 +12,13 @@ describe( 'Button', () => {
 	} );
 
 	it.each( [
-		'neutral',
-		'primaryProgressive',
-		'primaryDestructive',
-	] )( 'renders the type %s as a root node class', ( type ) => {
+		[ 'normal', 'neutral' ],
+		[ 'primary', 'progressive' ],
+		[ 'primary', 'destructive' ],
+	] )( 'renders the variant %s and type %s as a root node classes', ( variant, type ) => {
 		expect( mount( Button, {
 			propsData: {
+				variant,
 				type,
 			},
 		} ).classes() ).toContain( `wikit-Button--${type}` );
@@ -27,6 +28,23 @@ describe( 'Button', () => {
 		expect( () => mount( Button, {
 			propsData: {
 				type: 'random',
+			},
+		} ) ).toThrow();
+	} );
+
+	it( 'validates the variant prop', () => {
+		expect( () => mount( Button, {
+			propsData: {
+				variant: 'random',
+			},
+		} ) ).toThrow();
+	} );
+
+	it( 'throws for invalid combinations', () => {
+		expect( () => mount( Button, {
+			propsData: {
+				variant: 'primary',
+				type: 'neutral',
 			},
 		} ) ).toThrow();
 	} );


### PR DESCRIPTION
We want to support buttons that are of normal variant and progressive type.

Added a method to the updated hook to throw an error if an unsupported combination of variant and type is used by the application. For typing reasons this had to happen inside the Vue3 setup method.