### PR TITLE
Add a color to have the icon reuse the parent text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ development)_
 - Additional icon called edit
 - New icon called trash
 - New info-outline Icon type
+- New icon color `inherit` reuses the css `color` of the parent for the icon
 
 ### Removed
 

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -9,6 +9,6 @@ export enum IconTypes {
 	INFOOUTLINED = 'info-outlined',
 }
 
-export const iconColors = [ 'base', 'warning', 'error', 'notice', 'success' ];
+export const iconColors = [ 'base', 'warning', 'error', 'notice', 'success', 'inherit' ];
 
 export const iconSizes = [ 'medium', 'large' ];


### PR DESCRIPTION
This reuses the color in the css `color` attribute of the parent.

Bug: [T270330](https://phabricator.wikimedia.org/T270330)