### PR TITLE
Use <br> instead of trailing double-whitespace

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -18,18 +18,16 @@ import VueCompositionAPI, { defineComponent, onMounted } from '@vue/composition-
 
 Vue.use( VueCompositionAPI );
 
-/* eslint-disable no-trailing-spaces */
 /**
  *  An interactive element signaling a single-step action that will occur when the user clicks or taps on it.
- * 
+ *
  * Known issues:
- * 
- * * The styles defined on `:focus` do not apply in Safari and Firefox on macOS.  
- * This seems to be a desired behavior and not a bug  
- * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus  
+ *
+ * * The styles defined on `:focus` do not apply in Safari and Firefox on macOS.<br>
+ * This seems to be a desired behavior and not a bug<br>
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus<br>
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1581369#c5
  */
-/* eslint-enable no-trailing-spaces */
 export default defineComponent( {
 	name: 'Button',
 	props: {


### PR DESCRIPTION
HTML tags in doc comments aren't pretty, but many IDEs remove trailing
whitespaces automatically.