### PR TITLE
Comment deploy URL to PR

### DIFF
--- a/.github/workflows/comment-deploy-url-to-pr.yaml
+++ b/.github/workflows/comment-deploy-url-to-pr.yaml
@@ -1,0 +1,19 @@
+name: Comment deploy URL to PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    name: Comment deploy URL to PR
+    steps:
+      - name: Get branch hash
+        id: get_hash
+        run: echo "::set-output name=hash::$(echo 'refs/heads/${{ github.head_ref }}' | shasum | awk '{print $1}')"
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@1.0.1
+        with:
+          message: "<https://${{ steps.get_hash.outputs.hash }}--wmde-wikit.netlify.app>"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Please review #335 first**

This will comment the netlify deploy URL to the PR as soon as it's opened, which makes it more visible than it was before.

The way the URL is being generated is a little adventurous, but it should work as long as our netlify site isn't renamed.

... and ignore the two failed comments by the bot. For future PRs there will only be one comment with a URL that will remain the same (because of #335) even when the PR is updated.