### PR TITLE
Export Icon component

### DIFF
--- a/vue-components/src/main.ts
+++ b/vue-components/src/main.ts
@@ -3,6 +3,7 @@ import TextInput from './components/TextInput.vue';
 import Lookup from './components/Lookup.vue';
 import Dropdown from './components/Dropdown.vue';
 import Message from './components/Message.vue';
+import Icon from './components/Icon.vue';
 
 export {
 	Button,
@@ -10,4 +11,5 @@ export {
 	TextInput,
 	Lookup,
 	Message,
+	Icon,
 };


### PR DESCRIPTION
To be able to to create the icon-only buttons as they are showcased in Storybook, the consuming application needs access to the Wikit Icon component.
Therefore, it can no longer be an internal component.