### PR TITLE
vue-components: Add "display: block" to Input component

### DIFF
--- a/vue-components/src/components/Input.vue
+++ b/vue-components/src/components/Input.vue
@@ -54,6 +54,7 @@ export default Vue.extend( {
 	transition-duration: $wikit-Input-transition-duration;
 	transition-timing-function: $wikit-Input-transition-timing-function;
 	transition-property: $wikit-Input-transition-property;
+	display: block;
 
 	// Sets a basis for the inset box-shadow transition which otherwise doesn't work in Firefox.
 	// https://stackoverflow.com/questions/25410207/css-transition-not-working-on-box-shadow-property/25410897


### PR DESCRIPTION
Without it, the input gets extremely long when there something after it
to support the "width: 100%" css rule. With this, it gets just as long
as needed.