### PR TITLE
Fix checkbox's width

### DIFF
--- a/vue-components/src/components/Checkbox.vue
+++ b/vue-components/src/components/Checkbox.vue
@@ -60,8 +60,8 @@ $label: '.wikit-checkbox__label';
 		align-items: center;
 
 		&::before {
-			width: $wikit-Checkbox-input-size;
-			height: $wikit-Checkbox-input-size;
+			min-width: $wikit-Checkbox-input-size;
+			min-height: $wikit-Checkbox-input-size;
 			box-sizing: border-box;
 
 			border-width: $wikit-Checkbox-input-border-width;


### PR DESCRIPTION
Applying min-width (and min-height, just in case) to prevent the checkbox input from shrinking.

Issue: [T272609](https://phabricator.wikimedia.org/T272609) (1)