### PR TITLE
Fix pseudo-selector order

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -127,6 +127,13 @@ $base: '.wikit-Button';
 			background-color: $wikit-Button-normal-neutral-background-color;
 			border-color: $wikit-Button-normal-neutral-border-color;
 
+			&:focus {
+				color: $wikit-Button-normal-neutral-focus-color;
+				background-color: $wikit-Button-normal-neutral-focus-background-color;
+				border-color: $wikit-Button-normal-neutral-focus-border-color;
+				box-shadow: $wikit-Button-normal-neutral-focus-box-shadow;
+			}
+
 			&:hover {
 				color: $wikit-Button-normal-neutral-hover-color;
 				background-color: $wikit-Button-normal-neutral-hover-background-color;
@@ -137,13 +144,7 @@ $base: '.wikit-Button';
 				color: $wikit-Button-normal-neutral-active-color;
 				background-color: $wikit-Button-normal-neutral-active-background-color;
 				border-color: $wikit-Button-normal-neutral-active-border-color;
-			}
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				color: $wikit-Button-normal-neutral-focus-color;
-				background-color: $wikit-Button-normal-neutral-focus-background-color;
-				border-color: $wikit-Button-normal-neutral-focus-border-color;
-				box-shadow: $wikit-Button-normal-neutral-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
 	}
@@ -154,6 +155,12 @@ $base: '.wikit-Button';
 			background-color: $wikit-Button-primary-progressive-background-color;
 			border-color: $wikit-Button-primary-progressive-border-color;
 
+			&:focus {
+				background-color: $wikit-Button-primary-progressive-focus-background-color;
+				border-color: $wikit-Button-primary-progressive-focus-border-color;
+				box-shadow: $wikit-Button-primary-progressive-focus-box-shadow;
+			}
+
 			&:hover {
 				background-color: $wikit-Button-primary-progressive-hover-background-color;
 				border-color: $wikit-Button-primary-progressive-hover-border-color;
@@ -162,13 +169,7 @@ $base: '.wikit-Button';
 			&:active {
 				background-color: $wikit-Button-primary-progressive-active-background-color;
 				border-color: $wikit-Button-primary-progressive-active-border-color;
-			}
-
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				background-color: $wikit-Button-primary-progressive-focus-background-color;
-				border-color: $wikit-Button-primary-progressive-focus-border-color;
-				box-shadow: $wikit-Button-primary-progressive-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
 
@@ -176,6 +177,12 @@ $base: '.wikit-Button';
 			color: $wikit-Button-primary-color;
 			background-color: $wikit-Button-primary-destructive-background-color;
 			border-color: $wikit-Button-primary-destructive-border-color;
+
+			&:focus {
+				background-color: $wikit-Button-primary-destructive-focus-background-color;
+				border-color: $wikit-Button-primary-destructive-focus-border-color;
+				box-shadow: $wikit-Button-primary-destructive-focus-box-shadow;
+			}
 
 			&:hover {
 				background-color: $wikit-Button-primary-destructive-hover-background-color;
@@ -185,13 +192,7 @@ $base: '.wikit-Button';
 			&:active {
 				background-color: $wikit-Button-primary-destructive-active-background-color;
 				border-color: $wikit-Button-primary-destructive-active-border-color;
-			}
-
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				background-color: $wikit-Button-primary-destructive-focus-background-color;
-				border-color: $wikit-Button-primary-destructive-focus-border-color;
-				box-shadow: $wikit-Button-primary-destructive-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
 	}
@@ -211,6 +212,13 @@ $base: '.wikit-Button';
 			background-color: $wikit-Button-quiet-background-color;
 			border-color: $wikit-Button-quiet-border-color;
 
+			&:focus {
+				color: $wikit-Button-quiet-neutral-focus-color;
+				background-color: $wikit-Button-quiet-neutral-focus-background-color;
+				border-color: $wikit-Button-quiet-neutral-focus-border-color;
+				box-shadow: $wikit-Button-quiet-neutral-focus-box-shadow;
+			}
+
 			&:hover {
 				color: $wikit-Button-quiet-neutral-hover-color;
 				background-color: $wikit-Button-quiet-neutral-hover-background-color;
@@ -221,20 +229,21 @@ $base: '.wikit-Button';
 				color: $wikit-Button-quiet-neutral-active-color;
 				background-color: $wikit-Button-quiet-neutral-active-background-color;
 				border-color: $wikit-Button-quiet-neutral-active-border-color;
-			}
-
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				color: $wikit-Button-quiet-neutral-focus-color;
-				background-color: $wikit-Button-quiet-neutral-focus-background-color;
-				border-color: $wikit-Button-quiet-neutral-focus-border-color;
-				box-shadow: $wikit-Button-quiet-neutral-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
+
 		&#{$base}--progressive {
 			color: $wikit-Button-quiet-progressive-color;
 			background-color: $wikit-Button-quiet-background-color;
 			border-color: $wikit-Button-quiet-border-color;
+
+			&:focus {
+				color: $wikit-Button-quiet-progressive-focus-color;
+				background-color: $wikit-Button-quiet-progressive-focus-background-color;
+				border-color: $wikit-Button-quiet-progressive-focus-border-color;
+				box-shadow: $wikit-Button-quiet-progressive-focus-box-shadow;
+			}
 
 			&:hover {
 				color: $wikit-Button-quiet-progressive-hover-color;
@@ -246,20 +255,21 @@ $base: '.wikit-Button';
 				color: $wikit-Button-quiet-progressive-active-color;
 				background-color: $wikit-Button-quiet-progressive-active-background-color;
 				border-color: $wikit-Button-quiet-progressive-active-border-color;
-			}
-
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				color: $wikit-Button-quiet-progressive-focus-color;
-				background-color: $wikit-Button-quiet-progressive-focus-background-color;
-				border-color: $wikit-Button-quiet-progressive-focus-border-color;
-				box-shadow: $wikit-Button-quiet-progressive-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
+
 		&#{$base}--destructive {
 			color: $wikit-Button-quiet-destructive-color;
 			background-color: $wikit-Button-quiet-background-color;
 			border-color: $wikit-Button-quiet-border-color;
+
+			&:focus {
+				color: $wikit-Button-quiet-destructive-focus-color;
+				background-color: $wikit-Button-quiet-destructive-focus-background-color;
+				border-color: $wikit-Button-quiet-destructive-focus-border-color;
+				box-shadow: $wikit-Button-quiet-destructive-focus-box-shadow;
+			}
 
 			&:hover {
 				color: $wikit-Button-quiet-destructive-hover-color;
@@ -271,14 +281,7 @@ $base: '.wikit-Button';
 				color: $wikit-Button-quiet-destructive-active-color;
 				background-color: $wikit-Button-quiet-destructive-active-background-color;
 				border-color: $wikit-Button-quiet-destructive-active-border-color;
-			}
-
-			// A clicked button is both :active and :focused. Using :not(:active) to avoid mixing the two.
-			&:focus:not(:active) {
-				color: $wikit-Button-quiet-destructive-focus-color;
-				background-color: $wikit-Button-quiet-destructive-focus-background-color;
-				border-color: $wikit-Button-quiet-destructive-focus-border-color;
-				box-shadow: $wikit-Button-quiet-destructive-focus-box-shadow;
+				box-shadow: none;
 			}
 		}
 	}

--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -137,6 +137,7 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-normal-neutral-hover-color;
 				background-color: $wikit-Button-normal-neutral-hover-background-color;
+				border-color: $wikit-Button-normal-neutral-hover-border-color;
 			}
 
 			&:active {
@@ -146,8 +147,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-normal-neutral-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-normal-neutral-focus-border-color;
 			}
 		}
 	}
@@ -166,6 +167,7 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-progressive-hover-background-color;
+				border-color: $wikit-Button-primary-progressive-hover-border-color;
 			}
 
 			&:active {
@@ -174,8 +176,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-primary-progressive-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-primary-progressive-focus-border-color;
 			}
 		}
 
@@ -192,6 +194,7 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-destructive-hover-background-color;
+				border-color: $wikit-Button-primary-destructive-hover-border-color;
 			}
 
 			&:active {
@@ -200,8 +203,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-primary-destructive-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-primary-destructive-focus-border-color;
 			}
 		}
 	}
@@ -231,6 +234,7 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-neutral-hover-color;
 				background-color: $wikit-Button-quiet-neutral-hover-background-color;
+				border-color: $wikit-Button-quiet-neutral-hover-border-color;
 			}
 
 			&:active {
@@ -240,8 +244,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-quiet-neutral-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-quiet-neutral-focus-border-color;
 			}
 		}
 
@@ -260,6 +264,7 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-progressive-hover-color;
 				background-color: $wikit-Button-quiet-progressive-hover-background-color;
+				border-color: $wikit-Button-quiet-progressive-hover-border-color;
 			}
 
 			&:active {
@@ -269,8 +274,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-quiet-progressive-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-quiet-progressive-focus-border-color;
 			}
 		}
 
@@ -289,6 +294,7 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-destructive-hover-color;
 				background-color: $wikit-Button-quiet-destructive-hover-background-color;
+				border-color: $wikit-Button-quiet-destructive-hover-border-color;
 			}
 
 			&:active {
@@ -298,8 +304,8 @@ $base: '.wikit-Button';
 				box-shadow: none;
 			}
 
-			&:hover:not(:focus) {
-				border-color: $wikit-Button-quiet-destructive-hover-border-color;
+			&:focus:hover {
+				border-color: $wikit-Button-quiet-destructive-focus-border-color;
 			}
 		}
 	}

--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -137,7 +137,10 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-normal-neutral-hover-color;
 				background-color: $wikit-Button-normal-neutral-hover-background-color;
-				border-color: $wikit-Button-normal-neutral-hover-border-color;
+
+				&:not(:focus) {
+					border-color: $wikit-Button-normal-neutral-hover-border-color;
+				}
 			}
 
 			&:active {
@@ -163,7 +166,10 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-progressive-hover-background-color;
-				border-color: $wikit-Button-primary-progressive-hover-border-color;
+
+				&:not(:focus) {
+					border-color: $wikit-Button-primary-progressive-hover-border-color;
+				}
 			}
 
 			&:active {
@@ -186,7 +192,10 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-destructive-hover-background-color;
-				border-color: $wikit-Button-primary-destructive-hover-border-color;
+
+				&:not(:focus){
+					border-color: $wikit-Button-primary-destructive-hover-border-color;
+				}
 			}
 
 			&:active {
@@ -222,7 +231,10 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-neutral-hover-color;
 				background-color: $wikit-Button-quiet-neutral-hover-background-color;
-				border-color: $wikit-Button-quiet-neutral-hover-border-color;
+
+				&:not(:focus){
+					border-color: $wikit-Button-quiet-neutral-hover-border-color;
+				}
 			}
 
 			&:active {
@@ -248,7 +260,10 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-progressive-hover-color;
 				background-color: $wikit-Button-quiet-progressive-hover-background-color;
-				border-color: $wikit-Button-quiet-progressive-hover-border-color;
+
+				&:not(:focus){
+					border-color: $wikit-Button-quiet-progressive-hover-border-color;
+				}
 			}
 
 			&:active {
@@ -274,7 +289,10 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-destructive-hover-color;
 				background-color: $wikit-Button-quiet-destructive-hover-background-color;
-				border-color: $wikit-Button-quiet-destructive-hover-border-color;
+
+				&:not(:focus){
+					border-color: $wikit-Button-quiet-destructive-hover-border-color;
+				}
 			}
 
 			&:active {

--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -137,10 +137,6 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-normal-neutral-hover-color;
 				background-color: $wikit-Button-normal-neutral-hover-background-color;
-
-				&:not(:focus) {
-					border-color: $wikit-Button-normal-neutral-hover-border-color;
-				}
 			}
 
 			&:active {
@@ -148,6 +144,10 @@ $base: '.wikit-Button';
 				background-color: $wikit-Button-normal-neutral-active-background-color;
 				border-color: $wikit-Button-normal-neutral-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-normal-neutral-hover-border-color;
 			}
 		}
 	}
@@ -166,16 +166,16 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-progressive-hover-background-color;
-
-				&:not(:focus) {
-					border-color: $wikit-Button-primary-progressive-hover-border-color;
-				}
 			}
 
 			&:active {
 				background-color: $wikit-Button-primary-progressive-active-background-color;
 				border-color: $wikit-Button-primary-progressive-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-primary-progressive-hover-border-color;
 			}
 		}
 
@@ -192,16 +192,16 @@ $base: '.wikit-Button';
 
 			&:hover {
 				background-color: $wikit-Button-primary-destructive-hover-background-color;
-
-				&:not(:focus){
-					border-color: $wikit-Button-primary-destructive-hover-border-color;
-				}
 			}
 
 			&:active {
 				background-color: $wikit-Button-primary-destructive-active-background-color;
 				border-color: $wikit-Button-primary-destructive-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-primary-destructive-hover-border-color;
 			}
 		}
 	}
@@ -231,10 +231,6 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-neutral-hover-color;
 				background-color: $wikit-Button-quiet-neutral-hover-background-color;
-
-				&:not(:focus){
-					border-color: $wikit-Button-quiet-neutral-hover-border-color;
-				}
 			}
 
 			&:active {
@@ -242,6 +238,10 @@ $base: '.wikit-Button';
 				background-color: $wikit-Button-quiet-neutral-active-background-color;
 				border-color: $wikit-Button-quiet-neutral-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-quiet-neutral-hover-border-color;
 			}
 		}
 
@@ -260,10 +260,6 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-progressive-hover-color;
 				background-color: $wikit-Button-quiet-progressive-hover-background-color;
-
-				&:not(:focus){
-					border-color: $wikit-Button-quiet-progressive-hover-border-color;
-				}
 			}
 
 			&:active {
@@ -271,6 +267,10 @@ $base: '.wikit-Button';
 				background-color: $wikit-Button-quiet-progressive-active-background-color;
 				border-color: $wikit-Button-quiet-progressive-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-quiet-progressive-hover-border-color;
 			}
 		}
 
@@ -289,10 +289,6 @@ $base: '.wikit-Button';
 			&:hover {
 				color: $wikit-Button-quiet-destructive-hover-color;
 				background-color: $wikit-Button-quiet-destructive-hover-background-color;
-
-				&:not(:focus){
-					border-color: $wikit-Button-quiet-destructive-hover-border-color;
-				}
 			}
 
 			&:active {
@@ -300,6 +296,10 @@ $base: '.wikit-Button';
 				background-color: $wikit-Button-quiet-destructive-active-background-color;
 				border-color: $wikit-Button-quiet-destructive-active-border-color;
 				box-shadow: none;
+			}
+
+			&:hover:not(:focus) {
+				border-color: $wikit-Button-quiet-destructive-hover-border-color;
 			}
 		}
 	}

--- a/vue-components/src/components/ToggleButton.vue
+++ b/vue-components/src/components/ToggleButton.vue
@@ -1,123 +1,132 @@
 <template>
-	<button
-		:class="['wikit', 'wikit-ToggleButton', buttonIsActive ? 'wikit-ToggleButton--isActive' : null]"
-		@click="onClick"
-	>
-		<!-- @slot required. add the content of the button here (label, icon, etc.) -->
-		<slot />
-	</button>
+  <button
+    :class="[
+      'wikit',
+      'wikit-ToggleButton',
+      buttonIsActive ? 'wikit-ToggleButton--isActive' : null,
+    ]"
+    @click="onClick"
+  >
+    <!-- @slot required. add the content of the button here (label, icon, etc.) -->
+    <slot />
+  </button>
 </template>
 
 <script lang="ts">
-import Vue, { VueConstructor } from 'vue';
-import { ToggleButtonGroupInjection } from '@/components/ToggleButtonGroup.vue';
+import Vue, { VueConstructor } from "vue";
+import { ToggleButtonGroupInjection } from "@/components/ToggleButtonGroup.vue";
 
-export default ( Vue as VueConstructor<Vue & ToggleButtonGroupInjection> ).extend( {
-	name: 'ToggleButton',
-	methods: {
-		onClick(): void {
-			if ( this.toggleListener !== null ) {
-				this.toggleListener( this.value );
-				return;
-			}
-			/**
-			 * only emitted when not use as part of a ToggleButtonGroup
-			 */
-			this.$emit( 'click' );
-		},
-	},
-	inject: {
-		groupValue: { default: null },
-		toggleListener: { default: null },
-	} as Record<keyof ToggleButtonGroupInjection, object>,
-	computed: {
-		buttonIsActive(): boolean {
-			if ( this.groupValue !== null ) {
-				return this.groupValue() === this.value;
-			}
-			return this.isActive;
-		},
-	},
-	props: {
-		/**
-		 * required when the ToggleButton is used as part of a ToggleButtonGroup.
-		 */
-		value: {
-			default: null,
-			type: String,
-		},
-		/**
-		 * required when the ToggleButton is used as a standalone component.
-		 * Ignored when used as part of a ToggleButtonGroup
-		 */
-		isActive: {
-			default: false,
-			type: Boolean,
-		},
-	},
-} );
+export default (Vue as VueConstructor<Vue & ToggleButtonGroupInjection>).extend(
+  {
+    name: "ToggleButton",
+    methods: {
+      onClick(): void {
+        if (this.toggleListener !== null) {
+          this.toggleListener(this.value);
+          return;
+        }
+        /**
+         * only emitted when not use as part of a ToggleButtonGroup
+         */
+        this.$emit("click");
+      },
+    },
+    inject: {
+      groupValue: { default: null },
+      toggleListener: { default: null },
+    } as Record<keyof ToggleButtonGroupInjection, object>,
+    computed: {
+      buttonIsActive(): boolean {
+        if (this.groupValue !== null) {
+          return this.groupValue() === this.value;
+        }
+        return this.isActive;
+      },
+    },
+    props: {
+      /**
+       * required when the ToggleButton is used as part of a ToggleButtonGroup.
+       */
+      value: {
+        default: null,
+        type: String,
+      },
+      /**
+       * required when the ToggleButton is used as a standalone component.
+       * Ignored when used as part of a ToggleButtonGroup
+       */
+      isActive: {
+        default: false,
+        type: Boolean,
+      },
+    },
+  }
+);
 </script>
 
 <style lang="scss">
 .wikit-ToggleButton {
-	color: $wikit-ToggleButton-color;
-	font-family: $wikit-ToggleButton-font-family;
-	font-weight: $wikit-ToggleButton-font-weight;
-	font-size: $wikit-ToggleButton-font-size;
-	line-height: $wikit-ToggleButton-line-height;
-	box-sizing: border-box;
-	border-width: $wikit-ToggleButton-border-width;
-	border-style: $wikit-ToggleButton-border-style;
-	border-radius: $wikit-ToggleButton-border-radius;
-	border-color: $wikit-ToggleButton-border-color;
-	background-color: $wikit-ToggleButton-background-color;
-	padding-inline: $wikit-ToggleButton-medium-padding-horizontal;
-	padding-block: $wikit-ToggleButton-medium-padding-vertical;
-	transition-property: $wikit-ToggleButton-transition-property;
-	transition-duration: $wikit-ToggleButton-transition-duration;
-	transition-timing-function: $wikit-ToggleButton-transition-timing-function;
+  color: $wikit-ToggleButton-color;
+  font-family: $wikit-ToggleButton-font-family;
+  font-weight: $wikit-ToggleButton-font-weight;
+  font-size: $wikit-ToggleButton-font-size;
+  line-height: $wikit-ToggleButton-line-height;
+  box-sizing: border-box;
+  border-width: $wikit-ToggleButton-border-width;
+  border-style: $wikit-ToggleButton-border-style;
+  border-radius: $wikit-ToggleButton-border-radius;
+  border-color: $wikit-ToggleButton-border-color;
+  background-color: $wikit-ToggleButton-background-color;
+  padding-inline: $wikit-ToggleButton-medium-padding-horizontal;
+  padding-block: $wikit-ToggleButton-medium-padding-vertical;
+  transition-property: $wikit-ToggleButton-transition-property;
+  transition-duration: $wikit-ToggleButton-transition-duration;
+  transition-timing-function: $wikit-ToggleButton-transition-timing-function;
 
-	&:hover {
-		color: $wikit-ToggleButton-hover-color;
-		border-color: $wikit-ToggleButton-hover-border-color;
-		background-color: $wikit-ToggleButton-hover-background-color;
-	}
+  &:focus {
+    color: $wikit-ToggleButton-focus-color;
+    border-color: $wikit-ToggleButton-focus-border-color;
+    background-color: $wikit-ToggleButton-focus-background-color;
+    box-shadow: $wikit-ToggleButton-focus-box-shadow;
+    outline: none;
+  }
 
-	&:active {
-		color: $wikit-ToggleButton-active-color;
-		border-color: $wikit-ToggleButton-active-border-color;
-		background-color: $wikit-ToggleButton-active-background-color;
-	}
+  &:hover {
+    color: $wikit-ToggleButton-hover-color;
+    border-color: $wikit-ToggleButton-hover-border-color;
+    background-color: $wikit-ToggleButton-hover-background-color;
+  }
 
-	&:focus {
-		color: $wikit-ToggleButton-focus-color;
-		border-color: $wikit-ToggleButton-focus-border-color;
-		background-color: $wikit-ToggleButton-focus-background-color;
-		box-shadow: $wikit-ToggleButton-focus-box-shadow;
-		outline: none;
-	}
+  &:active {
+    color: $wikit-ToggleButton-active-color;
+    border-color: $wikit-ToggleButton-active-border-color;
+    background-color: $wikit-ToggleButton-active-background-color;
+  }
 
-	&:disabled {
-		color: $wikit-ToggleButton-disabled-color;
-		border-color: $wikit-ToggleButton-disabled-border-color;
-		background-color: $wikit-ToggleButton-disabled-background-color;
-	}
+  &:focus:hover {
+    border-color: $wikit-ToggleButton-focus-border-color;
+  }
 
-	@media (max-width: $width-breakpoint-mobile) {
-		padding-inline: $wikit-ToggleButton-large-padding-horizontal;
-		padding-block: $wikit-ToggleButton-large-padding-vertical;
-	}
+  &:disabled {
+    color: $wikit-ToggleButton-disabled-color;
+    border-color: $wikit-ToggleButton-disabled-border-color;
+    background-color: $wikit-ToggleButton-disabled-background-color;
+  }
+
+  @media (max-width: $width-breakpoint-mobile) {
+    padding-inline: $wikit-ToggleButton-large-padding-horizontal;
+    padding-block: $wikit-ToggleButton-large-padding-vertical;
+  }
 }
 
 .wikit-ToggleButton.wikit-ToggleButton--isActive {
-	color: $wikit-ToggleButton-selected-color;
-	border-color: $wikit-ToggleButton-selected-border-color;
-	background-color: $wikit-ToggleButton-selected-background-color;
+  color: $wikit-ToggleButton-selected-color;
+  border-color: $wikit-ToggleButton-selected-border-color;
+  background-color: $wikit-ToggleButton-selected-background-color;
 
-	&:focus {
-		box-shadow: $wikit-ToggleButton-selected-focus-box-shadow;
-		outline: none;
-	}
+  &:focus {
+    box-shadow: $wikit-ToggleButton-selected-focus-box-shadow;
+    outline: none;
+  }
 }
-
 </style>

--- a/vue-components/src/components/ToggleButton.vue
+++ b/vue-components/src/components/ToggleButton.vue
@@ -1,132 +1,127 @@
 <template>
-  <button
-    :class="[
-      'wikit',
-      'wikit-ToggleButton',
-      buttonIsActive ? 'wikit-ToggleButton--isActive' : null,
-    ]"
-    @click="onClick"
-  >
-    <!-- @slot required. add the content of the button here (label, icon, etc.) -->
-    <slot />
-  </button>
+	<button
+		:class="['wikit', 'wikit-ToggleButton', buttonIsActive ? 'wikit-ToggleButton--isActive' : null]"
+		@click="onClick"
+	>
+		<!-- @slot required. add the content of the button here (label, icon, etc.) -->
+		<slot />
+	</button>
 </template>
 
 <script lang="ts">
-import Vue, { VueConstructor } from "vue";
-import { ToggleButtonGroupInjection } from "@/components/ToggleButtonGroup.vue";
+import Vue, { VueConstructor } from 'vue';
+import { ToggleButtonGroupInjection } from '@/components/ToggleButtonGroup.vue';
 
-export default (Vue as VueConstructor<Vue & ToggleButtonGroupInjection>).extend(
-  {
-    name: "ToggleButton",
-    methods: {
-      onClick(): void {
-        if (this.toggleListener !== null) {
-          this.toggleListener(this.value);
-          return;
-        }
-        /**
-         * only emitted when not use as part of a ToggleButtonGroup
-         */
-        this.$emit("click");
-      },
-    },
-    inject: {
-      groupValue: { default: null },
-      toggleListener: { default: null },
-    } as Record<keyof ToggleButtonGroupInjection, object>,
-    computed: {
-      buttonIsActive(): boolean {
-        if (this.groupValue !== null) {
-          return this.groupValue() === this.value;
-        }
-        return this.isActive;
-      },
-    },
-    props: {
-      /**
-       * required when the ToggleButton is used as part of a ToggleButtonGroup.
-       */
-      value: {
-        default: null,
-        type: String,
-      },
-      /**
-       * required when the ToggleButton is used as a standalone component.
-       * Ignored when used as part of a ToggleButtonGroup
-       */
-      isActive: {
-        default: false,
-        type: Boolean,
-      },
-    },
-  }
-);
+export default ( Vue as VueConstructor<Vue & ToggleButtonGroupInjection> ).extend( {
+	name: 'ToggleButton',
+	methods: {
+		onClick(): void {
+			if ( this.toggleListener !== null ) {
+				this.toggleListener( this.value );
+				return;
+			}
+			/**
+			 * only emitted when not use as part of a ToggleButtonGroup
+			 */
+			this.$emit( 'click' );
+		},
+	},
+	inject: {
+		groupValue: { default: null },
+		toggleListener: { default: null },
+	} as Record<keyof ToggleButtonGroupInjection, object>,
+	computed: {
+		buttonIsActive(): boolean {
+			if ( this.groupValue !== null ) {
+				return this.groupValue() === this.value;
+			}
+			return this.isActive;
+		},
+	},
+	props: {
+		/**
+		 * required when the ToggleButton is used as part of a ToggleButtonGroup.
+		 */
+		value: {
+			default: null,
+			type: String,
+		},
+		/**
+		 * required when the ToggleButton is used as a standalone component.
+		 * Ignored when used as part of a ToggleButtonGroup
+		 */
+		isActive: {
+			default: false,
+			type: Boolean,
+		},
+	},
+} );
 </script>
 
 <style lang="scss">
 .wikit-ToggleButton {
-  color: $wikit-ToggleButton-color;
-  font-family: $wikit-ToggleButton-font-family;
-  font-weight: $wikit-ToggleButton-font-weight;
-  font-size: $wikit-ToggleButton-font-size;
-  line-height: $wikit-ToggleButton-line-height;
-  box-sizing: border-box;
-  border-width: $wikit-ToggleButton-border-width;
-  border-style: $wikit-ToggleButton-border-style;
-  border-radius: $wikit-ToggleButton-border-radius;
-  border-color: $wikit-ToggleButton-border-color;
-  background-color: $wikit-ToggleButton-background-color;
-  padding-inline: $wikit-ToggleButton-medium-padding-horizontal;
-  padding-block: $wikit-ToggleButton-medium-padding-vertical;
-  transition-property: $wikit-ToggleButton-transition-property;
-  transition-duration: $wikit-ToggleButton-transition-duration;
-  transition-timing-function: $wikit-ToggleButton-transition-timing-function;
+	color: $wikit-ToggleButton-color;
+	font-family: $wikit-ToggleButton-font-family;
+	font-weight: $wikit-ToggleButton-font-weight;
+	font-size: $wikit-ToggleButton-font-size;
+	line-height: $wikit-ToggleButton-line-height;
+	box-sizing: border-box;
+	border-width: $wikit-ToggleButton-border-width;
+	border-style: $wikit-ToggleButton-border-style;
+	border-radius: $wikit-ToggleButton-border-radius;
+	border-color: $wikit-ToggleButton-border-color;
+	background-color: $wikit-ToggleButton-background-color;
+	padding-inline: $wikit-ToggleButton-medium-padding-horizontal;
+	padding-block: $wikit-ToggleButton-medium-padding-vertical;
+	transition-property: $wikit-ToggleButton-transition-property;
+	transition-duration: $wikit-ToggleButton-transition-duration;
+	transition-timing-function: $wikit-ToggleButton-transition-timing-function;
 
-  &:focus {
-    color: $wikit-ToggleButton-focus-color;
-    border-color: $wikit-ToggleButton-focus-border-color;
-    background-color: $wikit-ToggleButton-focus-background-color;
-    box-shadow: $wikit-ToggleButton-focus-box-shadow;
-    outline: none;
-  }
+	&:focus {
+		color: $wikit-ToggleButton-focus-color;
+		border-color: $wikit-ToggleButton-focus-border-color;
+		background-color: $wikit-ToggleButton-focus-background-color;
+		box-shadow: $wikit-ToggleButton-focus-box-shadow;
+		outline: none;
+	}
 
-  &:hover {
-    color: $wikit-ToggleButton-hover-color;
-    border-color: $wikit-ToggleButton-hover-border-color;
-    background-color: $wikit-ToggleButton-hover-background-color;
-  }
+	&:hover {
+		color: $wikit-ToggleButton-hover-color;
+		border-color: $wikit-ToggleButton-hover-border-color;
+		background-color: $wikit-ToggleButton-hover-background-color;
+	}
 
-  &:active {
-    color: $wikit-ToggleButton-active-color;
-    border-color: $wikit-ToggleButton-active-border-color;
-    background-color: $wikit-ToggleButton-active-background-color;
-  }
+	&:active {
+		color: $wikit-ToggleButton-active-color;
+		border-color: $wikit-ToggleButton-active-border-color;
+		background-color: $wikit-ToggleButton-active-background-color;
+	}
 
-  &:focus:hover {
-    border-color: $wikit-ToggleButton-focus-border-color;
-  }
+	&:focus:hover {
+		border-color: $wikit-ToggleButton-focus-border-color;
+	}
 
-  &:disabled {
-    color: $wikit-ToggleButton-disabled-color;
-    border-color: $wikit-ToggleButton-disabled-border-color;
-    background-color: $wikit-ToggleButton-disabled-background-color;
-  }
+	&:disabled {
+		color: $wikit-ToggleButton-disabled-color;
+		border-color: $wikit-ToggleButton-disabled-border-color;
+		background-color: $wikit-ToggleButton-disabled-background-color;
+	}
 
-  @media (max-width: $width-breakpoint-mobile) {
-    padding-inline: $wikit-ToggleButton-large-padding-horizontal;
-    padding-block: $wikit-ToggleButton-large-padding-vertical;
-  }
+	@media (max-width: $width-breakpoint-mobile) {
+		padding-inline: $wikit-ToggleButton-large-padding-horizontal;
+		padding-block: $wikit-ToggleButton-large-padding-vertical;
+	}
 }
 
 .wikit-ToggleButton.wikit-ToggleButton--isActive {
-  color: $wikit-ToggleButton-selected-color;
-  border-color: $wikit-ToggleButton-selected-border-color;
-  background-color: $wikit-ToggleButton-selected-background-color;
+	color: $wikit-ToggleButton-selected-color;
+	border-color: $wikit-ToggleButton-selected-border-color;
+	background-color: $wikit-ToggleButton-selected-background-color;
 
-  &:focus {
-    box-shadow: $wikit-ToggleButton-selected-focus-box-shadow;
-    outline: none;
-  }
+	&:focus {
+		box-shadow: $wikit-ToggleButton-selected-focus-box-shadow;
+		outline: none;
+	}
 }
+
 </style>


### PR DESCRIPTION
This PR aims to fix an issue with hover styles by correcting the pseudo selector order to reflect the overrides performed by the user. i.e. an element is:

1. First `:focus`ed (most general case)
2. Then `:hover`ed (specific case before activated, desktop only)
3. And only then potentially `:active`ated

In this case the selector cascade reflects that flow and thus does not require a higher specificity to perform overrides.

See: https://phabricator.wikimedia.org/T266557
Bug: T266557 