### PR TITLE
Fix logo url to link to home page

### DIFF
--- a/docs/.storybook/wikit.js
+++ b/docs/.storybook/wikit.js
@@ -4,6 +4,6 @@ import { create } from '@storybook/theming/create';
 export default create( {
 	base: 'light',
 	brandTitle: 'WiKit',
-	brandUrl: 'wmde.github.io/wikit',
+	brandUrl: '/',
 	brandImage: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Wikidata_heart_logo.svg/274px-Wikidata_heart_logo.svg.png',
 } );


### PR DESCRIPTION
This PR aims to fix the wikit logo link.

Phabricator: https://phabricator.wikimedia.org/T266326
Bug: T266326