### PR TITLE
fix: keyboard scroll of OptionsMenu not working on Chrome

### DIFF
--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -130,10 +130,14 @@ export default Vue.extend( {
 			const element = this.$refs[ 'menu-items' ] as HTMLElement[];
 
 			if ( this.keyboardHoveredItemIndex !== -1 ) {
-				element[ this.keyboardHoveredItemIndex ].scrollIntoView( {
-					behavior: 'smooth',
-					block: 'end',
-					inline: 'nearest',
+				/**
+				 * This setTimeout shouldn't be needed, but it is a workaround to make scrollIntoView with options
+				 * work in Chrome 88, but that problem likely existed on older Chrome versions as well.
+				 *
+				 * TODO: With newer versions of Chrome, try removing the setTimeout and see if it works.
+				 */
+				setTimeout( () => {
+					element[ this.keyboardHoveredItemIndex ].scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 				} );
 			}
 		},

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -159,10 +159,12 @@ describe( 'Dropdown', () => {
 
 			const scrollIntoViewMock = jest.fn();
 			Element.prototype.scrollIntoView = scrollIntoViewMock;
+			jest.useFakeTimers();
 
 			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
+			jest.runAllTimers();
+			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -225,10 +225,12 @@ describe( 'Lookup', () => {
 
 		const scrollIntoViewMock = jest.fn();
 		Element.prototype.scrollIntoView = scrollIntoViewMock;
+		jest.useFakeTimers();
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
+		jest.runAllTimers();
+		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 


### PR DESCRIPTION
Apparently, Chrome is not supporting the options for scrollIntoView.
Therefore we fall back to the basic boolean parameter. This results in a
somewhat more abrupt scroll. That issue can maybe be revisited in future
versions, possibly after support for IE11 has been officially dropped.

Bug: [T272999](https://phabricator.wikimedia.org/T272999)