### PR TITLE
fix: only scroll menu if option is not yet visible

### DIFF
--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -130,11 +130,7 @@ export default Vue.extend( {
 			const element = this.$refs[ 'menu-items' ] as HTMLElement[];
 
 			if ( this.keyboardHoveredItemIndex !== -1 ) {
-				element[ this.keyboardHoveredItemIndex ].scrollIntoView( {
-					behavior: 'smooth',
-					block: 'end',
-					inline: 'nearest',
-				} );
+				element[ this.keyboardHoveredItemIndex ].scrollIntoView( false );
 			}
 		},
 		resizeMenu(): void {

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -127,10 +127,10 @@ export default Vue.extend( {
 			}
 		},
 		keyboardScroll(): void {
-			const element = this.$refs[ 'menu-items' ] as HTMLElement[];
+			const currentElement = ( this.$refs[ 'menu-items' ] as HTMLElement[] )[ this.keyboardHoveredItemIndex ];
 
-			if ( this.keyboardHoveredItemIndex !== -1 ) {
-				element[ this.keyboardHoveredItemIndex ].scrollIntoView( false );
+			if ( this.keyboardHoveredItemIndex !== -1 && !this.isElementVisible( currentElement ) ) {
+				currentElement.scrollIntoView( false );
 			}
 		},
 		resizeMenu(): void {
@@ -144,18 +144,21 @@ export default Vue.extend( {
 				this.maxHeight = null;
 			}
 		},
-		onScroll: debounce( function ( this: Vue ) {
+		isElementVisible( menuItem: HTMLElement ): boolean {
 			const rootElem = this.$refs[ 'lookup-menu' ] as HTMLElement;
-			const menuItems = this.$refs[ 'menu-items' ] as HTMLElement[];
 			const menuTop = rootElem.scrollTop;
 			const menuBottom = menuTop + rootElem.offsetHeight;
 
+			const elementTop = menuItem.offsetTop;
+			const elementBottom = menuItem.offsetTop + menuItem.offsetHeight;
+
+			return elementBottom <= menuBottom && elementTop >= menuTop;
+		},
+		onScroll: debounce( function ( this: Vue & { isElementVisible: ( menuItem: HTMLElement ) => boolean } ) {
+			const menuItems = this.$refs[ 'menu-items' ] as HTMLElement[];
 			const visibleElems = [];
 			for ( let i = 0; i < menuItems.length; i++ ) {
-				const elementTop = menuItems[ i ].offsetTop;
-				const elementBottom = menuItems[ i ].offsetTop + menuItems[ i ].offsetHeight;
-
-				if ( elementTop <= menuBottom && elementBottom >= menuTop ) {
+				if ( this.isElementVisible( menuItems[ i ] ) ) {
 					visibleElems.push( i );
 				}
 			}

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -157,35 +157,27 @@ describe( 'Dropdown', () => {
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
 			expect( wrapper.find( highlightedItemLabelSelector ).exists() ).toBe( false );
 
-			const scrollIntoViewMock = jest.fn();
-			Element.prototype.scrollIntoView = scrollIntoViewMock;
-
 			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
-			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -223,35 +223,27 @@ describe( 'Lookup', () => {
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).exists() ).toBe( false );
 
-		const scrollIntoViewMock = jest.fn();
-		Element.prototype.scrollIntoView = scrollIntoViewMock;
-
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
 		wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
-		expect( scrollIntoViewMock ).toHaveBeenCalled();
 		await Vue.nextTick();
 		expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 		expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );


### PR DESCRIPTION
When navigating the OptionsMenu with the keyboard, then it should only
scroll to a new option, if that option is not yet fully visible.