### PR TITLE
Visualize token dependencies

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5103,6 +5103,273 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
+		"d3": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-6.5.0.tgz",
+			"integrity": "sha512-gr7FoRecKtBkBxelTeGVYERRTPgjPFLh2rOBisHdbXe3RIrVLjCo7COZYMSeFeiwVPOHDtxAGJlvN7XssNAIcg==",
+			"requires": {
+				"d3-array": "2",
+				"d3-axis": "2",
+				"d3-brush": "2",
+				"d3-chord": "2",
+				"d3-color": "2",
+				"d3-contour": "2",
+				"d3-delaunay": "5",
+				"d3-dispatch": "2",
+				"d3-drag": "2",
+				"d3-dsv": "2",
+				"d3-ease": "2",
+				"d3-fetch": "2",
+				"d3-force": "2",
+				"d3-format": "2",
+				"d3-geo": "2",
+				"d3-hierarchy": "2",
+				"d3-interpolate": "2",
+				"d3-path": "2",
+				"d3-polygon": "2",
+				"d3-quadtree": "2",
+				"d3-random": "2",
+				"d3-scale": "3",
+				"d3-scale-chromatic": "2",
+				"d3-selection": "2",
+				"d3-shape": "2",
+				"d3-time": "2",
+				"d3-time-format": "3",
+				"d3-timer": "2",
+				"d3-transition": "2",
+				"d3-zoom": "2"
+			}
+		},
+		"d3-array": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.11.0.tgz",
+			"integrity": "sha512-26clcwmHQEdsLv34oNKq5Ia9tQ26Y/4HqS3dQzF42QBUqymZJ+9PORcN1G52bt37NsL2ABoX4lvyYZc+A9Y0zw==",
+			"requires": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"d3-axis": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.0.0.tgz",
+			"integrity": "sha512-9nzB0uePtb+u9+dWir+HTuEAKJOEUYJoEwbJPsZ1B4K3iZUgzJcSENQ05Nj7S4CIfbZZ8/jQGoUzGKFznBhiiQ=="
+		},
+		"d3-brush": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+			"integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+			"requires": {
+				"d3-dispatch": "1 - 2",
+				"d3-drag": "2",
+				"d3-interpolate": "1 - 2",
+				"d3-selection": "2",
+				"d3-transition": "2"
+			}
+		},
+		"d3-chord": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+			"integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+			"requires": {
+				"d3-path": "1 - 2"
+			}
+		},
+		"d3-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+			"integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+		},
+		"d3-contour": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+			"integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+			"requires": {
+				"d3-array": "2"
+			}
+		},
+		"d3-delaunay": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+			"integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+			"requires": {
+				"delaunator": "4"
+			}
+		},
+		"d3-dispatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+			"integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+		},
+		"d3-drag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+			"integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+			"requires": {
+				"d3-dispatch": "1 - 2",
+				"d3-selection": "2"
+			}
+		},
+		"d3-dsv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+			"integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+			"requires": {
+				"commander": "2",
+				"iconv-lite": "0.4",
+				"rw": "1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				}
+			}
+		},
+		"d3-ease": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+			"integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
+		},
+		"d3-fetch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+			"integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
+			"requires": {
+				"d3-dsv": "1 - 2"
+			}
+		},
+		"d3-force": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+			"integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+			"requires": {
+				"d3-dispatch": "1 - 2",
+				"d3-quadtree": "1 - 2",
+				"d3-timer": "1 - 2"
+			}
+		},
+		"d3-format": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+			"integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+		},
+		"d3-geo": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
+			"integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+			"requires": {
+				"d3-array": ">=2.5"
+			}
+		},
+		"d3-hierarchy": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+			"integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+		},
+		"d3-interpolate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+			"integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+			"requires": {
+				"d3-color": "1 - 2"
+			}
+		},
+		"d3-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+			"integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+		},
+		"d3-polygon": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+			"integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
+		},
+		"d3-quadtree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+			"integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+		},
+		"d3-random": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+			"integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
+		},
+		"d3-scale": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+			"integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+			"requires": {
+				"d3-array": "^2.3.0",
+				"d3-format": "1 - 2",
+				"d3-interpolate": "1.2.0 - 2",
+				"d3-time": "1 - 2",
+				"d3-time-format": "2 - 3"
+			}
+		},
+		"d3-scale-chromatic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+			"integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+			"requires": {
+				"d3-color": "1 - 2",
+				"d3-interpolate": "1 - 2"
+			}
+		},
+		"d3-selection": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+			"integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+		},
+		"d3-shape": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.0.0.tgz",
+			"integrity": "sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==",
+			"requires": {
+				"d3-path": "1 - 2"
+			}
+		},
+		"d3-time": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
+			"integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+		},
+		"d3-time-format": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+			"integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+			"requires": {
+				"d3-time": "1 - 2"
+			}
+		},
+		"d3-timer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+			"integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+		},
+		"d3-transition": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+			"integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+			"requires": {
+				"d3-color": "1 - 2",
+				"d3-dispatch": "1 - 2",
+				"d3-ease": "1 - 2",
+				"d3-interpolate": "1 - 2",
+				"d3-timer": "1 - 2"
+			}
+		},
+		"d3-zoom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+			"integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+			"requires": {
+				"d3-dispatch": "1 - 2",
+				"d3-drag": "2",
+				"d3-interpolate": "1 - 2",
+				"d3-selection": "2",
+				"d3-transition": "2"
+			}
+		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -5199,6 +5466,11 @@
 					"dev": true
 				}
 			}
+		},
+		"delaunator": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+			"integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -7917,7 +8189,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -8171,6 +8442,11 @@
 				"has": "^1.0.3",
 				"side-channel": "^1.0.2"
 			}
+		},
+		"internmap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.0.tgz",
+			"integrity": "sha512-SdoDWwNOTE2n4JWUsLn4KXZGuZPjPF9yyOGc8bnfWnBQh7BD/l80rzSznKc/r4Y0aQ7z3RTk9X+tV4tHBpu+dA=="
 		},
 		"interpret": {
 			"version": "2.2.0",
@@ -11705,6 +11981,11 @@
 				"aproba": "^1.1.1"
 			}
 		},
+		"rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+		},
 		"rxjs": {
 			"version": "6.6.3",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
@@ -11732,8 +12013,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@wmde/wikit-tokens": "^2.0.0-alpha.6",
     "@wmde/wikit-vue-components": "^2.0.0-alpha.6",
+    "d3": "^6.5.0",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/docs/src/13-token-dependencies.stories.mdx
+++ b/docs/src/13-token-dependencies.stories.mdx
@@ -1,0 +1,8 @@
+import { Meta, Typeset } from '@storybook/addon-docs/blocks';
+import { TokenDependencies } from './lib/TokenDependencies';
+
+<Meta title="Design Tokens/Token Dependencies" />
+
+## Token Dependency Graph
+
+<TokenDependencies />

--- a/docs/src/lib/TokenDependencies.css
+++ b/docs/src/lib/TokenDependencies.css
@@ -1,0 +1,4 @@
+.line {
+	fill: none;
+	stroke: #eee;
+}

--- a/docs/src/lib/TokenDependencies.jsx
+++ b/docs/src/lib/TokenDependencies.jsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import * as tokenTree from '@wmde/wikit-tokens/dist/all.json';
+import { flattenTokenTree } from './flattenTokenTree';
+import './TokenDependencies.css';
+
+// The eslint-disable below shouldn't be necessary. The config should allow modern ES syntax.
+/* eslint-disable no-restricted-syntax */
+
+const tokens = flattenTokenTree( tokenTree );
+
+function findByName( token ) {
+	return tokens.find( ( t ) => t.name === token );
+}
+
+function guessTokenGroup( token ) {
+	if ( token.name.startsWith( 'wmf-' ) ) {
+		return 'wmf';
+	} else if ( token.name.startsWith( 'wikit-' ) ) {
+		return 'component';
+	} else if (
+		token.referencedTokens.length === 0 ||
+		guessTokenGroup( findByName( token.referencedTokens[ 0 ] ) ) === 'wmf'
+	) {
+		return 'global';
+	}
+
+	return 'alias';
+}
+
+function buildDependencyChain( initialToken ) {
+	const chain = [ initialToken ];
+	let token = findByName( initialToken );
+
+	while ( token.referencedTokens.length > 0 ) {
+		// TODO make this work for tokens referencing multiple other tokens.
+		chain.push( token.referencedTokens[ 0 ] );
+		token = findByName( token.referencedTokens[ 0 ] );
+	}
+
+	return chain;
+}
+
+export function TokenDependencies() {
+	const tokenGroups = [
+		{
+			type: 'wmf',
+			tokens: [],
+		},
+		{
+			type: 'global',
+			tokens: [],
+		},
+		{
+			type: 'alias',
+			tokens: [],
+		},
+		{
+			type: 'component',
+			tokens: [],
+		},
+	];
+	tokens.forEach( ( token ) => {
+		tokenGroups.find( ( g ) => g.type === guessTokenGroup( token ) )
+			.tokens.push( token.name );
+	} );
+
+	const tokenChains = [];
+	tokenGroups.reverse().forEach( ( group ) => {
+		group.tokens.forEach( ( token ) => {
+			if ( tokenChains.some( ( chain ) => chain.includes( token ) ) ) {
+				return;
+			}
+
+			tokenChains.push( buildDependencyChain( token ) );
+		} );
+	} );
+
+	tokenGroups.reverse().forEach( ( group ) => group.tokens.sort() );
+
+	const graphDiv = useRef( null );
+	useEffect( () => {
+		// Strange things happen without the uniqueness trick in the following line:
+		// For some reason in the storybook built in CI (but not locally) maxTokensInGroup
+		// was 2x what it was expected to be. Not sure what's going on there.
+		tokenGroups.forEach( ( g ) => {
+			g.tokens = [ ...new Set( g.tokens ) ];
+		} );
+
+		const tokenTypes = tokenGroups.map( ( t ) => t.type );
+
+		function getTokenGroup( token ) {
+			return tokenGroups.find( ( tokenType ) => tokenType.tokens.includes( token ) );
+		}
+
+		function getTokenType( token ) {
+			return getTokenGroup( token ).type;
+		}
+
+		const maxTokensInGroup = d3.max( tokenGroups, ( group ) => group.tokens.length );
+
+		const margin = { top: 20, right: 20, bottom: 30, left: 150 };
+		const width = tokenGroups.length * 400 - margin.left - margin.right;
+		const height = maxTokensInGroup * 30 - margin.top - margin.bottom;
+		const x = d3.scaleLinear().range( [ 0, width ] );
+		const y = d3.scaleLinear().range( [ height, 0 ] );
+
+		x.domain( [ 0, tokenTypes.length ] );
+		y.domain( [ 0, maxTokensInGroup ] );
+
+		// eslint-disable-next-line func-style
+		const xPos = ( token ) => x( tokenTypes.indexOf( getTokenType( token ) ) );
+		// eslint-disable-next-line func-style
+		const yPos = ( token ) => y( getTokenGroup( token ).tokens.indexOf( token ) );
+
+		const svg = d3.select( graphDiv.current ).append( 'svg' )
+			.attr( 'width', width + margin.left + margin.right )
+			.attr( 'height', height + margin.top + margin.bottom )
+			.append( 'g' )
+			.attr( 'transform', `translate(${margin.left}, ${margin.top})` )
+			.selectAll( 'g' )
+			.data( tokenChains )
+			.join( 'g' );
+
+		// adds one line per token dependency chain to the diagram
+		svg.append( 'path' )
+			.attr( 'class', 'line' )
+			.attr( 'd', d3.line().x( xPos ).y( yPos ) );
+
+		// adds clickable labels
+		svg.append( 'g' )
+			.attr( 'font-family', 'sans-serif' )
+			.attr( 'font-size', 16 )
+			.attr( 'cursor', 'pointer' )
+			.attr( 'stroke-linecap', 'round' )
+			.attr( 'stroke-linejoin', 'round' )
+			.attr( 'text-anchor', 'middle' )
+			.selectAll( 'text' )
+			.data( ( d ) => d )
+			.join( 'text' )
+			.text( ( token ) => token )
+			.attr( 'dy', '0.35em' )
+			.attr( 'x', xPos )
+			.attr( 'y', yPos )
+			.on( 'click', ( e, selectedToken ) => {
+				// eslint-disable-next-line func-style
+				const isSelectedPath = ( tokens ) => tokens.includes( selectedToken );
+				// eslint-disable-next-line func-style
+				const isPartOfSelectedPath = ( token ) => {
+					return tokenChains
+						.some( ( c ) => c.includes( selectedToken ) && c.includes( token ) );
+				};
+				svg.selectAll( 'path' )
+					.style( 'stroke', ( tokens ) => isSelectedPath( tokens ) ? '#000' : '#eee' )
+					.filter( isSelectedPath )
+					.each( function () {
+						d3.select( this.parentNode ).raise();
+					} );
+				svg.selectAll( 'text' )
+					.style( 'fill', ( token ) => isPartOfSelectedPath( token ) ? '#000' : '#ddd' );
+			} )
+			.clone( true ).lower()
+			.attr( 'fill', 'none' )
+			.attr( 'stroke', 'white' )
+			.attr( 'stroke-width', 16 );
+	} );
+	return ( <div ref={graphDiv} /> );
+}

--- a/tokens/.style-dictionary/config.js
+++ b/tokens/.style-dictionary/config.js
@@ -54,6 +54,9 @@ const StyleDictionary = require( 'style-dictionary' ),
 					destination: 'index.json',
 					format: 'json',
 					filter: removeWikimediaUiBaseVars,
+				}, {
+					destination: 'all.json',
+					format: 'json',
 				} ],
 			},
 			jsonSchema: {

--- a/tokens/.style-dictionary/lib.js
+++ b/tokens/.style-dictionary/lib.js
@@ -12,7 +12,7 @@ function getReferencedTokens( prop ) {
 
 	return {
 		tokens: [ ...prop.original.value.matchAll( variablePattern ) ]
-			.map( ( match ) => match.groups.token ),
+			.map( ( match ) => match.groups.token.replace( /\./g, '-' ) ),
 	};
 }
 


### PR DESCRIPTION
<sup>Disclaimer: I threw this together on "volunteer" time while playing with d3.js. Only parking it here because it looks like it has potential. Very hacky and unpolished.</sup>

This lists all tokens in a single diagram and visualizes how they depend on each other. Clicking on a token shows its children and parent. Multiple parents aren't shown (yet). Columns depict specificity: wikimedia-ui-base -> global -> alias -> component-level.

![Screenshot 2021-02-28 at 15 25 36](https://user-images.githubusercontent.com/453024/109424582-6c374d00-79e4-11eb-8e7f-64877e0bfc4c.png)
[Try it out!](https://e887f03b79db66f997bb4b2fb8da4e78ccc20de1--wmde-wikit.netlify.app/?path=/story/design-tokens-token-dependencies--page)

The diagram is too big and cluttered as it is, but it could be useful if we make it filterable or split it somehow.

Bug: https://phabricator.wikimedia.org/T260425