### PR TITLE
ci: pin paths-filter to previous version to avoid CI failure

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -20,7 +20,7 @@ jobs:
       with:
         fetch-depth: 0 # chromatic needs access to the history
     - name: Check Paths
-      uses: dorny/paths-filter@v2
+      uses: dorny/paths-filter@v2.9.0
       id: filter
       with:
         filters: |


### PR DESCRIPTION
The latest release of the paths-filter action 2.9.1 caused a failure of all CI update jobs. This release contained a single PR dorny/paths-filter#74

The error message in all of our CI setup jobs was:

```
Run dorny/paths-filter@v2
  with:
    filters: visual:
    - 'tokens/**'
    - 'vue-components/**'
  behavioral:
    - 'vue-components/**'

    token: ***
    list-files: none
    initial-fetch-depth: 100
Changes will be detected against the branch master
Searching for merge-base master...QuantityInput
  /usr/bin/git rev-list --count --all
  640
  /usr/bin/git merge-base master QuantityInput
  fatal: Not a valid object name master
  /usr/bin/git fetch --depth=1280 origin master:master QuantityInput
  From wmde/wikit
   * [new branch]      master     -> master
   * branch            QuantityInput -> FETCH_HEAD
  /usr/bin/git rev-list --count --all
  640
  No more commits were fetched
  Last attempt will be to fetch full history
  /usr/bin/git fetch --unshallow
  fatal: --unshallow on a complete repository does not make sense
Error: The process '/usr/bin/git' failed with exit code 128
```