### PR TITLE
Update 04_release_management.stories.mdx

### DIFF
--- a/docs/src/00-doc/04_release_management.stories.mdx
+++ b/docs/src/00-doc/04_release_management.stories.mdx
@@ -26,11 +26,13 @@ It is also their responsibility to inform other relevant roles like UX and PM (i
 
 ## Creating a pre-release 
 
-If you want to be able to test components and features prior to their official release, you may create a pre-release. To make a pre-release you need to take the following steps:
- - To release a new version run the command `npm run bump-version -- [premajor | preminor | prepatch | prerelease]`. This will take care of updating the version number in all package.json files.
+If you want to be able to test components and features prior to their official release, you may create a pre-release. To make a pre-release you need to take the following steps: 
+ - Create a new branch from master and switch to it
+ - To release a new version, run the command `npm run bump-version -- [premajor | preminor | prepatch | prerelease]`. This will take care of updating the version number in all package.json files.
+ - Select `custom pre-release` and hit enter to use the default
  - Commit and push the changes you made to package files and open a PR.
  - After the PR is merged, create and push a new tag named after the version number with a "v" prefix and an `alpha` suffix, e.g. `v1.2.3-alpha.0` (0 stands for the first pre-release of this version, for each consecutive pre-release this number must be incremented).
- - Then go to the GitHub repository and create a new pre-release out of that tag.
+ - Then go to the [Releases page](https://github.com/wmde/wikit/releases) in wikit's GitHub repository and click `Draft a new release`to create a new pre-release out of that tag.
 
   _**Note:** there is no need to describe the changes, as this is simply a pre release_.
 
@@ -42,6 +44,8 @@ If you want to be able to test components and features prior to their official r
 
  - Creating the new release will trigger a GitHub action, which will publish **both** the `tokens` and the `vue-components` packages under the `next` distribution tag on npm.
  - Go to https://www.npmjs.com/ to check the newly created versions.
+
+_**Note:** after creating the pre-release, you can go to https://www.npmjs.com/package/@wmde/wikit-vue-components/v/{{ LATEST_VERSION}} (e.g. https://www.npmjs.com/package/@wmde/wikit-vue-components/v/2.0.0-alpha.9 ). If you don't see 404 on the page, that means the realse is in NPM. (if you see 404, wait a few minutes and refresh the page)_.
 
 
 ## Creating a release 

--- a/docs/src/00-doc/04_release_management.stories.mdx
+++ b/docs/src/00-doc/04_release_management.stories.mdx
@@ -29,7 +29,6 @@ It is also their responsibility to inform other relevant roles like UX and PM (i
 If you want to be able to test components and features prior to their official release, you may create a pre-release. To make a pre-release you need to take the following steps: 
  - Create a new branch from master and switch to it
  - To release a new version, run the command `npm run bump-version -- [premajor | preminor | prepatch | prerelease]`. This will take care of updating the version number in all package.json files.
- - Select `custom pre-release` and hit enter to use the default
  - Commit and push the changes you made to package files and open a PR.
  - After the PR is merged, create and push a new tag named after the version number with a "v" prefix and an `alpha` suffix, e.g. `v1.2.3-alpha.0` (0 stands for the first pre-release of this version, for each consecutive pre-release this number must be incremented).
  - Then go to the [Releases page](https://github.com/wmde/wikit/releases) in wikit's GitHub repository and click `Draft a new release`to create a new pre-release out of that tag.


### PR DESCRIPTION
Devs in the Query builder hike are using their own notes on pre-release steps ([see notes](https://mattermost.wikimedia.de/swe/pl/bf3859p1oircbxasa56c99q5zy)). That made me think that probably the documentation was not sufficiently detailed or clear. I had to interpret where some of the steps defined would fit the current process outline, so a review is highly appreciated.