### PR TITLE
correct bg-color of focused normal neutral buttons

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -219,7 +219,7 @@
                     "value": "{color.base.80.value}"
                 },
                 "focus": {
-                    "value": "{color.base.100.value}"
+                    "value": "{color.base.90.value}"
                 }
             },
             "destructive": {

--- a/tokens/properties/components/Button.json
+++ b/tokens/properties/components/Button.json
@@ -97,7 +97,7 @@
                         "value": "{border.color.neutral.focus.value}"
                     },
                     "background-color": {
-                        "value": "{background.color.neutral.hover.value}"
+                        "value": "{background.color.neutral.focus.value}"
                     },
                     "box-shadow": {
                         "value": "{box-shadow.inset.focus.progressive.value}"


### PR DESCRIPTION
Tiny PR to correct the token applied to define the background color of normal neutral buttons on focus.