### PR TITLE
Add missing color classes and props to icon component

### DIFF
--- a/vue-components/src/components/Icon.vue
+++ b/vue-components/src/components/Icon.vue
@@ -224,15 +224,15 @@ export default Vue.extend( {
 	&--base {
 		color: $wikit-Icon-color-base;
 	}
-	
+
 	&--subtle {
 		color: $wikit-Icon-color-subtle;
 	}
-	
+
 	&--emphasized {
 		color: $wikit-Icon-color-emphasized;
 	}
-	
+
 	&--inverted {
 		color: $wikit-Icon-color-inverted;
 	}

--- a/vue-components/src/components/Icon.vue
+++ b/vue-components/src/components/Icon.vue
@@ -224,6 +224,18 @@ export default Vue.extend( {
 	&--base {
 		color: $wikit-Icon-color-base;
 	}
+	
+	&--subtle {
+		color: $wikit-Icon-color-subtle;
+	}
+	
+	&--emphasized {
+		color: $wikit-Icon-color-emphasized;
+	}
+	
+	&--inverted {
+		color: $wikit-Icon-color-inverted;
+	}
 
 	&--error {
 		color: $wikit-Icon-color-error;

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -13,6 +13,6 @@ export enum IconTypes {
 	SEARCH = 'search'
 }
 
-export const iconColors = [ 'base', 'warning', 'error', 'notice', 'success', 'inherit' ];
+export const iconColors = [ 'base', 'subtle', 'emphasized', 'inverted', 'warning', 'error', 'notice', 'success', 'inherit' ];
 
 export const iconSizes = [ 'xsmall', 'small', 'medium', 'large' ];

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -22,7 +22,7 @@ export const iconColors = [
 	'error',
 	'notice',
 	'success',
-	'inherit'
+	'inherit',
 ];
 
 export const iconSizes = [ 'xsmall', 'small', 'medium', 'large' ];

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -13,6 +13,16 @@ export enum IconTypes {
 	SEARCH = 'search'
 }
 
-export const iconColors = [ 'base', 'subtle', 'emphasized', 'inverted', 'warning', 'error', 'notice', 'success', 'inherit' ];
+export const iconColors = [
+	'base',
+	'subtle',
+	'emphasized',
+	'inverted',
+	'warning',
+	'error',
+	'notice',
+	'success',
+	'inherit'
+];
 
 export const iconSizes = [ 'xsmall', 'small', 'medium', 'large' ];


### PR DESCRIPTION
This should allow applying the subtle, emphasized and inverted colors to the icon component.

This is what happens when you keep forgetting that you can run tests locally 🙈