### PR TITLE
Create default placeholder class for Extender

### DIFF
--- a/tokens/properties/components/InputExtender.json
+++ b/tokens/properties/components/InputExtender.json
@@ -39,6 +39,23 @@
                 "vertical": {
                     "value": "{dimension.spacing.xsmall.value}"
                 }
+            },
+            "placeholder": {
+                "font-family": {
+                    "value": "{font.family.style.placeholder.value}"
+                },
+                "font-size": {
+                    "value": "{font.size.style.placeholder.value}"
+                },
+                "font-weight": {
+                    "value": "{font.weight.style.placeholder.value}"
+                },
+                "line-height": {
+                    "value": "{font.line-height.style.placeholder.value}"
+                },
+                "color": {
+                    "value": "{font.color.subtle.value}"
+                }
             }
         }
     }

--- a/vue-components/src/components/InputWithExtender.vue
+++ b/vue-components/src/components/InputWithExtender.vue
@@ -17,7 +17,7 @@
 			:placeholder="placeholder"
 			:disabled="disabled"
 		/>
-		<div v-if="showExtension" class="wikit-InputWithExtender__extension">
+		<div v-if="showExtension" class="wikit-InputWithExtender__extension wikit-InputWithExtender__placeholder">
 			<slot />
 		</div>
 		<ValidationMessage
@@ -107,6 +107,14 @@ export default defineComponent( {
 		border: $wikit-InputExtender-border-width $wikit-InputExtender-border-style $wikit-InputExtender-border-color;
 		box-shadow: $wikit-InputExtender-box-shadow;
 		border-radius: $wikit-InputExtender-border-radius;
+	}
+
+	&__placeholder {
+		font-family: $wikit-InputExtender-content-placeholder-font-family;
+		font-size: $wikit-InputExtender-content-placeholder-font-size;
+		font-weight: $wikit-InputExtender-content-placeholder-font-weight;
+		line-height: $wikit-InputExtender-content-placeholder-line-height;
+		color: $wikit-InputExtender-content-placeholder-color;
 	}
 
 }

--- a/vue-components/stories/InputWithExtender.stories.ts
+++ b/vue-components/stories/InputWithExtender.stories.ts
@@ -18,7 +18,7 @@ export function basic( args: { content: string; underlined: boolean } ): Compone
         template: `
 			<div>
 				<InputWithExtender :label="label" :disabled="disabled" placeholder="Placeholder" style="width: 300px;">
-                  <div style="font-family: sans-serif; font-style: normal; font-weight: normal; font-size: 16px; line-height: 20px; color: #72777D;">
+                  <div>
                     Menu content placeholder. Any text or component can be displayed here.
                   </div>
                 </InputWithExtender>


### PR DESCRIPTION
Adding an extra class to (hopefully) style the text included in the Extender menu by default.