### PR TITLE
Avoid emitting 'update:isShown' when not needed

### DIFF
--- a/vue-components/src/components/Popover.vue
+++ b/vue-components/src/components/Popover.vue
@@ -70,6 +70,9 @@ export default Vue.extend( {
 			this.changeContentVisibility( false );
 		},
 		changeContentVisibility( isVisible: boolean ): void {
+			if ( isVisible === this.isContentShown ) {
+				return;
+			}
 			this.isContentShown = isVisible;
 			/**
 			 * This can optionally be used with the `.sync` modifier on the `isShown` prop


### PR DESCRIPTION
Currently, doing any debug shows a lot of these events being emitted
making debugging much harder (and also has performance costs). Let's
just not do it.