### PR TITLE
Add preventDefault to keydown handlers of menu items and dropdown

### DIFF
--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -131,6 +131,7 @@ export default defineComponent( {
 					}
 					break;
 				case 'ArrowDown':
+					event.preventDefault();
 					this.startShowingTheMenu();
 			}
 			this.menu?.onKeyDown( event );

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -98,6 +98,7 @@ export default Vue.extend( {
 					this.$emit( 'esc' );
 					break;
 				case 'ArrowUp':
+					event.preventDefault();
 					if ( this.allowLooping && this.keyboardHoveredItemIndex === 0 ) {
 						// loop to the bottom of the menu
 						this.keyboardHoveredItemIndex = this.menuItems.length - 1;
@@ -108,6 +109,7 @@ export default Vue.extend( {
 					this.keyboardScroll();
 					break;
 				case 'ArrowDown':
+					event.preventDefault();
 					if ( this.allowLooping && this.keyboardHoveredItemIndex === this.menuItems.length - 1 ) {
 						// go back to the top of the menu
 						this.keyboardHoveredItemIndex = 0;


### PR DESCRIPTION
Similar to what ooui has done:
https://doc.wikimedia.org/oojs-ui/master/js/source/DropdownWidget.html#OO-ui-DropdownWidget

This prevents the whole screen to scroll when you use keyboard to
navigate through items.

Bug: T277759