### PR TITLE
Fix label word wrap

### DIFF
--- a/vue-components/src/components/Checkbox.vue
+++ b/vue-components/src/components/Checkbox.vue
@@ -57,7 +57,6 @@ $label: '.wikit-checkbox__label';
 		@include Label;
 		display: flex;
 		align-items: center;
-		word-break: break-all;
 		margin-inline-end: $dimension-spacing-small;
 
 		&::before {

--- a/vue-components/src/styles/mixins/Label.scss
+++ b/vue-components/src/styles/mixins/Label.scss
@@ -1,12 +1,14 @@
-@mixin Label( $displayType: 'inline' ) {
-    color: $wikit-Label-font-color;
-    font-family: $wikit-Label-font-family;
-    font-size: $wikit-Label-font-size;
-    font-weight: $wikit-Label-font-weight;
-    line-height: $wikit-Label-line-height;
-    display: $displayType;
+@mixin Label($displayType: "inline") {
+  color: $wikit-Label-font-color;
+  font-family: $wikit-Label-font-family;
+  font-size: $wikit-Label-font-size;
+  font-weight: $wikit-Label-font-weight;
+  line-height: $wikit-Label-line-height;
+  display: $displayType;
+  overflow-wrap: break-word;
+  hyphens: auto;
 
-    @if $displayType == block {
-        padding-block-end: $wikit-Label-padding-block-end;
-    }
+  @if $displayType == block {
+    padding-block-end: $wikit-Label-padding-block-end;
+  }
 }


### PR DESCRIPTION
This should prevent the words in any label text from breaking arbitrarily whenever their content wraps. Hyphenation is also introduced to prevent creating disproportionate white space between lines when long words are present.

Before:

<img width="279" alt="Screenshot 2021-04-14 at 19 29 09" src="https://user-images.githubusercontent.com/3887458/114753386-b176ca80-9d57-11eb-97c9-f67d1e02762f.png">

After:

<img width="255" alt="Screenshot 2021-04-14 at 19 29 42" src="https://user-images.githubusercontent.com/3887458/114753450-c3f10400-9d57-11eb-92ac-2bf39b1aa821.png">
