### PR TITLE
Fix checkbox input alignment

### DIFF
--- a/vue-components/src/components/Checkbox.vue
+++ b/vue-components/src/components/Checkbox.vue
@@ -74,6 +74,7 @@ $label: '.wikit-checkbox__label';
 			content: ' ';
 			margin-inline-end: $wikit-Checkbox-input-right-spacing;
 			display: flex;
+			align-self: flex-start;
 			transition-property: $wikit-Checkbox-input-transition-property;
 			transition-duration: $wikit-Checkbox-input-transition-duration;
 			transition-timing-function: $wikit-Checkbox-input-transition-timing-function;

--- a/vue-components/stories/Checkbox.stories.ts
+++ b/vue-components/stories/Checkbox.stories.ts
@@ -60,6 +60,11 @@ export function all(): Component {
 						</template>
 				</Checkbox>
 				</div>
+				<br>
+				<div dir="ltr" style="max-width: 320px">
+					<Checkbox label="This checkbox has a longer label to demonstrate the vertical alignment of the input at the top" :checked="false"></Checkbox>
+				</Checkbox>
+				</div>
 			</div>
 		`,
 	};


### PR DESCRIPTION
This makes the checkbox input to always be aligned with the first line of text of its label. A checkbox with a longer label was included in the _All_ story  page in order to showcase the changes.

Issue: [T272609](https://phabricator.wikimedia.org/T272609) (Number 4)