### PR TITLE
Correct inset styles of filled components on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ development)_
 
 - _**(Breaking)**_ Width property is removed from all components
 - Cursor tokens
+- The token "box-shadow-button-primary" 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ development)_
 
 - _**(Breaking)**_ Width property is removed from all components
 - Cursor tokens
-- The token "box-shadow-button-primary" 
+- The token "box-shadow-inset-focus-button-primary" 
 
 ### Fixed
 

--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -482,12 +482,7 @@
                     "value": "{box-shadow.inset.style.thin.value} {color.utility.yellow.30.value}"
                 },
                 "inverted": {
-                    "value": "{box-shadow.inset.style.thin.value} {color.base.100.value}",
-                    "comment": "Binary inputs"
-                },
-                "button-primary": {
-                    "value": "{box-shadow.inset.style.thick.value} {color.base.100.value}",
-                    "comment": "Only applies to filled primary buttons"
+                    "value": "{box-shadow.inset.style.thick.value} {color.base.100.value}"
                 }
             }
         },

--- a/tokens/properties/components/Button.json
+++ b/tokens/properties/components/Button.json
@@ -289,7 +289,7 @@
                         "value": "{background.color.progressive.focus.value}"
                     },
                     "box-shadow": {
-                        "value": "{box-shadow.inset.focus.button-primary.value}"
+                        "value": "{box-shadow.inset.focus.progressive.value}, {box-shadow.inset.focus.inverted.value}"
                     }
                 }
             },
@@ -324,7 +324,7 @@
                         "value": "{background.color.destructive.focus.value}"
                     },
                     "box-shadow": {
-                        "value": "{box-shadow.inset.focus.button-primary.value}"
+                        "value": "{box-shadow.inset.focus.destructive.value}, {box-shadow.inset.focus.inverted.value}"
                     }
                 }
             },

--- a/tokens/properties/components/Checkbox.json
+++ b/tokens/properties/components/Checkbox.json
@@ -1,9 +1,9 @@
 {
     "wikit-Checkbox": {
         "label": {
-            "disabled":{
+            "disabled": {
                 "color": {
-                    "value":"{font.color.disabled.value}"
+                    "value": "{font.color.disabled.value}"
                 }
             }
         },
@@ -97,7 +97,7 @@
                         "value": "{background.color.progressive.default.value}"
                     },
                     "box-shadow": {
-                        "value": "{box-shadow.inset.focus.inverted.value}"
+                        "value": "{box-shadow.inset.focus.progressive.value}, {box-shadow.inset.focus.inverted.value}"
                     }
                 }
             },

--- a/tokens/properties/components/ToggleButton.json
+++ b/tokens/properties/components/ToggleButton.json
@@ -113,7 +113,10 @@
             },
             "focus": {
                 "box-shadow": {
-                    "value": "{box-shadow.inset.focus.inverted.value}"
+                    "value": "{box-shadow.inset.focus.progressive.value}, {box-shadow.inset.focus.inverted.value}"
+                },
+                "border-color": {
+                    "value": "{border.color.progressive.focus.value}"
                 }
             }
         },

--- a/vue-components/src/components/ToggleButton.vue
+++ b/vue-components/src/components/ToggleButton.vue
@@ -120,6 +120,7 @@ export default ( Vue as VueConstructor<Vue & ToggleButtonGroupInjection> ).exten
 
 	&:focus {
 		box-shadow: $wikit-ToggleButton-selected-focus-box-shadow;
+		border-color: $wikit-ToggleButton-selected-focus-border-color;
 		outline: none;
 	}
 }


### PR DESCRIPTION
💥 Breaking changes 💥

This applies the right box-shadow (and border) styles to filled elements on focus. Alias tokens were deleted or modified.

Affected components: 

- Primary buttons (progressive & destructive, iconOnly)
- Checkbox
- Toggle button

Issue: [T272626](https://phabricator.wikimedia.org/T272626)