### PR TITLE
Update postcss plugin to be compatible with postcss 8

### DIFF
--- a/vue-components/build/postcssWikitScope.js
+++ b/vue-components/build/postcssWikitScope.js
@@ -1,4 +1,3 @@
-const postcss = require( 'postcss' );
 const selectorParser = require( 'postcss-selector-parser' );
 
 // copied & modified from https://github.com/pazams/postcss-scopify/blob/master/index.js#L86
@@ -24,12 +23,16 @@ function applyWikitScope( selector ) {
 	return `.wikit ${selector}, ${addWikitClassToFirstSelectorNode.processSync( selector )}`;
 }
 
-module.exports = postcss.plugin( 'wikit-scope', () => ( ( root ) => {
-	root.walkRules( ( rule ) => {
-		if ( !isRuleScopable( rule ) ) {
-			return;
-		}
+module.exports = () => {
+	return {
+		postcssPlugin: 'wikit-scope',
+		Rule( rule ) {
+			if ( !isRuleScopable( rule ) ) {
+				return;
+			}
 
-		rule.selectors = rule.selectors.map( applyWikitScope );
-	} );
-} ) );
+			rule.selectors = rule.selectors.map( applyWikitScope );
+		},
+	};
+};
+module.exports.postcss = true;

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -80,7 +80,7 @@
     "jest-axe": "^4.1.0",
     "jest-serializer-vue": "^2.0.2",
     "npm-run-all": "^4.1.5",
-    "postcss": "^7.0.35",
+    "postcss": "^8.2.15",
     "postcss-dir-pseudo-class": "^5.0.0",
     "postcss-inline-svg": "^4.1.0",
     "postcss-logical": "^4.0.2",


### PR DESCRIPTION
This makes our postcss plugin compatible with postcss 8 based on what is apparently the official migration guide: https://evilmartians.com/chronicles/postcss-8-plugin-migration

This became an issue due to the automatic dependabot pull request for postcss 8 in #427.

However, this currently doesn't work since our dependency of postcss is not what is actually run when building Wikit. What is actually run is the postcss as specified by vue-cli, which still depends on postcss 7. The plugin as written in this PR is not compatible with postcss 7.

That being said, the vulnerability due to which dependabot created this PR #427 does't affect us. As stated in https://github.com/postcss/postcss/commit/8682b1e4e328432ba692bed52326e84439cec9e4#commitcomment-49809613:

> [...] it affects only use cases when:
>
>     1. User send you CSS
>
>     2. You compile this CSS on your servers
>
>
> In this case, the user can generate special CSS which will take seconds or minutes to compile. An attacker can use it to DoS your servers.
>
> If you can’t update PostCSS, you can add timeout for CSS processing.

Though, this patch can, and maybe should, be applied when we upgrade vue-cli or otherwise are able to actually make use of postcss v8 as it may represent a performance improvement.