### PR TITLE
Fix docs about path to variables.css

### DIFF
--- a/docs/src/00-doc/01_getting_started.stories.mdx
+++ b/docs/src/00-doc/01_getting_started.stories.mdx
@@ -52,8 +52,8 @@ You can use them in any type of front end.
 
 The tokens are served in three different formats:
 
-`@import '~@wmde/wikit-tokens/dist/_variables_.less';`
+`@import '~@wmde/wikit-tokens/dist/_variables.less';`
 
-`@import '~@wmde/wikit-tokens/dist/_variables_.scss';`
+`@import '~@wmde/wikit-tokens/dist/_variables.scss';`
 
-`@import '~@wmde/wikit-tokens/dist/_variables_.css';`
+`@import '~@wmde/wikit-tokens/dist/variables.css';`


### PR DESCRIPTION
The underscores are not needed when one wants to include *variables.css*.