### PR TITLE
Move Dropdown keydown listener to select element

### DIFF
--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -1,7 +1,6 @@
 <template>
 	<div
 		:class="[ 'wikit', 'wikit-Dropdown' ]"
-		@keydown="triggerKeyDown"
 	>
 		<span class="wikit-Dropdown__label-wrapper">
 			<label
@@ -22,6 +21,7 @@
 			:disabled="disabled"
 			@click="onClick"
 			@blur="showMenu = false"
+			@keydown="triggerKeyDown"
 			ref="select"
 		>
 			<span

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -69,7 +69,7 @@ describe( 'Dropdown', () => {
 
 	it( 'shows the Dropdown menu on pressing Enter', async () => {
 		const wrapper = mount( Dropdown );
-		wrapper.trigger( 'keydown', { key: 'Enter' } );
+		wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'Enter' } );
 
 		await Vue.nextTick();
 		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
@@ -91,7 +91,7 @@ describe( 'Dropdown', () => {
 		const scrollIntoViewMock = jest.fn();
 		Element.prototype.scrollIntoView = scrollIntoViewMock;
 
-		wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+		wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'ArrowDown' } );
 		await Vue.nextTick();
 
 		expect( wrapper.findComponent( OptionsMenu ).isVisible() ).toBe( true );
@@ -151,6 +151,7 @@ describe( 'Dropdown', () => {
 			const highlightedItemLabelSelector = '.wikit-OptionsMenu__item--hovered .wikit-OptionsMenu__item__label';
 
 			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
+			const selectWrapper = wrapper.find( '.wikit-Dropdown__select' );
 			const OptionsMenuWrapper = wrapper.findComponent( OptionsMenu );
 
 			expect( OptionsMenuWrapper.isVisible() ).toBe( true );
@@ -161,32 +162,32 @@ describe( 'Dropdown', () => {
 			Element.prototype.scrollIntoView = scrollIntoViewMock;
 			jest.useFakeTimers();
 
-			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			selectWrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 			await Vue.nextTick();
 			jest.runAllTimers();
 			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
-			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			selectWrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
-			wrapper.trigger( 'keydown', { key: 'ArrowDown' } );
+			selectWrapper.trigger( 'keydown', { key: 'ArrowDown' } );
 			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'potato' );
 
-			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
+			selectWrapper.trigger( 'keydown', { key: 'ArrowUp' } );
 			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 1 );
 			expect( wrapper.find( highlightedItemLabelSelector ).text() ).toBe( 'duck' );
 
-			wrapper.trigger( 'keydown', { key: 'ArrowUp' } );
+			selectWrapper.trigger( 'keydown', { key: 'ArrowUp' } );
 			expect( scrollIntoViewMock ).toHaveBeenCalled();
 			await Vue.nextTick();
 			expect( OptionsMenuWrapper.vm.$data.keyboardHoveredItemIndex ).toBe( 0 );
@@ -202,7 +203,7 @@ describe( 'Dropdown', () => {
 			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
 
 			wrapper.findComponent( OptionsMenu ).setData( { keyboardHoveredItemIndex: 0 } );
-			wrapper.trigger( 'keydown', { key: 'Escape' } );
+			wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'Escape' } );
 
 			await Vue.nextTick();
 
@@ -221,7 +222,7 @@ describe( 'Dropdown', () => {
 			const keyboardHoveredItemIndex = 0;
 			wrapper.findComponent( OptionsMenu ).setData( { keyboardHoveredItemIndex } );
 
-			wrapper.trigger( 'keydown', { key: 'Tab' } );
+			wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'Tab' } );
 
 			expect( wrapper.emitted( 'input' )!.pop() ).toStrictEqual( [ menuItems[ keyboardHoveredItemIndex ] ] );
 		} );
@@ -238,7 +239,7 @@ describe( 'Dropdown', () => {
 			const keyboardHoveredItemIndex = 0;
 			OptionsMenuWrapper.setData( { keyboardHoveredItemIndex } );
 
-			wrapper.trigger( 'keydown', { key: 'Enter' } );
+			wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'Enter' } );
 			await Vue.nextTick();
 
 			expect( OptionsMenuWrapper.isVisible() ).toBe( false );
@@ -252,7 +253,7 @@ describe( 'Dropdown', () => {
 			];
 
 			const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems );
-			wrapper.trigger( 'keydown', { key: 'Enter' } );
+			wrapper.find( '.wikit-Dropdown__select' ).trigger( 'keydown', { key: 'Enter' } );
 
 			expect( wrapper.findComponent( OptionsMenu ).vm.$data.keyboardHoveredItemIndex ).toBe( -1 );
 


### PR DESCRIPTION
This event listener shouldn’t be called for events bubbling up from the label (including any components in the suffix slot).

Bug: [T277762](https://phabricator.wikimedia.org/T277762)

---

Tested with the following storybook patch:

```diff
diff --git a/vue-components/stories/Popover.stories.ts b/vue-components/stories/Popover.stories.ts
index 24ce522..941aaf4 100644
--- a/vue-components/stories/Popover.stories.ts
+++ b/vue-components/stories/Popover.stories.ts
@@ -1,5 +1,6 @@
 import Popover from '@/components/Popover';
 import Icon from '@/components/Icon';
+import Dropdown from '@/components/Dropdown';
 import Button from '@/components/Button';
 import { PopoverPositions } from '@/components/PopoverProps';
 import { Component } from 'vue';
@@ -115,3 +116,32 @@ export function all(): Component {
 all.parameters = {
     controls: { hideNoControlsWarning: true },
 };
+
+export function T277762(): Component {
+    return {
+        components: {
+            Button,
+            Dropdown,
+            Icon,
+            Popover,
+        },
+        template: `
+            <Dropdown
+                :menuItems="[{label: 'label', description: 'description'}]"
+                label="a dropdown"
+                style="margin: 5em;"
+            >
+                <template v-slot:suffix>
+                    <Popover>
+                        <template v-slot:target>
+                            <Button iconOnly>
+                                <Icon type="info-outlined" size="small" />
+                            </Button>
+                        </template>
+                      Popover content
+                    </Popover>
+                </template>
+            </Dropdown>
+        `,
+    };
+}
```