### PR TITLE
ci: run on pull requests

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -5,7 +5,11 @@
 #
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 name: Test and Deploy
 jobs:
 
@@ -108,6 +112,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: setup
+    if: ${{ github.repository_owner == 'wikit' }}
     outputs:
       deploy_url: ${{ steps.netlify_deploy.outputs.url }}
     steps:


### PR DESCRIPTION
Run CI on pull requests, including external ones. To avoid double CI runs, this means we no longer run CI on pushes, except to the master branch (after a pull request was merged). The deploy job is skipped on external pull requests, since the secrets won’t be available; this should cause the browser-tests job to be skipped as well.

Bug: [T283911](https://phabricator.wikimedia.org/T283911)