### PR TITLE
Restore real timers in tests that use fake timers

### DIFF
--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -16,6 +16,9 @@ async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[] ): P
 }
 
 describe( 'Dropdown', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
 
 	it( 'has a label', () => {
 		const label = 'a label';

--- a/vue-components/tests/unit/components/LookupCore.spec.ts
+++ b/vue-components/tests/unit/components/LookupCore.spec.ts
@@ -19,6 +19,9 @@ async function createLookupInputWrapperWithExpandedMenu( menuItems: MenuItem[] )
 }
 
 describe( 'LookupInput', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
 
 	it( 'shows the previously selected menu item after regaining focus, if available', async () => {
 		const menuItems = [

--- a/vue-components/tests/unit/components/Popover.spec.ts
+++ b/vue-components/tests/unit/components/Popover.spec.ts
@@ -4,6 +4,10 @@ import Popover from '@/components/Popover.vue';
 const localVue = createLocalVue();
 
 describe( 'Popover', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
 	it( 'shows and hides in accordance with isShown prop', async () => {
 		const wrapper = shallowMount( Popover, {
 			propsData: {


### PR DESCRIPTION
The Jest documentation for [Timer Mocks][1] says that this doesn’t happen automatically, and we probably want to clean up timers between tests.

[1]: https://jestjs.io/docs/timer-mocks