### PR TITLE
Convert hard coded calculation into a token value

### DIFF
--- a/tokens/properties/mixins/BouncingDots.json
+++ b/tokens/properties/mixins/BouncingDots.json
@@ -7,12 +7,12 @@
             "value": "{border.radius.circle.value}"
         },
         "margin-left": {
-            "value": "{dimension.dynamic.size.100.value}/4",
-            "comment": "not sure the operation is going to work"
+            "value": "{dimension.dynamic.size.25.value}",
+            "comment": "Encoding this value as 100/4 = 25"
         },
         "margin-right": {
-            "value": "{dimension.dynamic.size.100.value}/4",
-            "comment": "not sure the operation is going to work"
+            "value": "{dimension.dynamic.size.25.value}",
+            "comment": "Encoding this value as 100/4 = 25"
         },
         "width-small": {
             "value": "{dimension.dynamic.size.75.value}"


### PR DESCRIPTION
This change converts a hard-coded calculation value in  the tokens source into a token value, as the hard-coded calculation was generating code that was both unusable in the CSS variable sheets (CSS does not understand `/` without `calc`) and was causing the sass compiler to emit deprecation warnings.

Bug: [T288809](https://phabricator.wikimedia.org/T288809)