### PR TITLE
Upstream TextArea component from Mismatch Finder

### DIFF
--- a/vue-components/src/components/ResizeLimit.ts
+++ b/vue-components/src/components/ResizeLimit.ts
@@ -1,0 +1,14 @@
+enum ResizeLimit {
+	Horizontal = 'horizontal',
+	Vertical = 'vertical',
+	None = 'none'
+}
+
+function validateLimit( limit: string ): boolean {
+	return Object.values( ResizeLimit ).includes( limit as ResizeLimit );
+}
+
+export {
+	ResizeLimit,
+	validateLimit,
+};

--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -1,0 +1,171 @@
+<template>
+	<div class="wikit wikit-TextArea">
+		<span class="wikit-TextArea__label-wrapper">
+			<label
+				:class="[
+					'wikit-TextArea__label'
+				]"
+				:for="id"
+			>
+				{{ label }}
+			</label>
+		</span>
+		<textarea
+			:class="[
+				'wikit-TextArea__textarea',
+				`wikit-TextArea__textarea--${resizeType}`
+			]"
+			:rows="rows"
+			:placeholder="placeholder"
+			label=""
+			@input="$emit( 'input', $event.target.value )"
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import generateId from '@/components/util/generateUid';
+import { ResizeLimit, validateLimit } from '@/components/ResizeLimit';
+
+export default Vue.extend( {
+	props: {
+		label: {
+			type: String,
+			default: '',
+		},
+		placeholder: {
+			type: String,
+			default: '',
+		},
+		rows: {
+			type: Number,
+			default: 2,
+		},
+		resize: {
+			type: String,
+			validator( value: ResizeLimit ): boolean {
+				return validateLimit( value );
+			},
+			default: ResizeLimit.Vertical,
+		},
+	},
+
+	data() {
+		return {
+			// https://github.com/vuejs/vue/issues/5886
+			id: generateId( 'wikit-TextArea' ),
+		};
+	},
+
+	computed: {
+		resizeType(): string {
+			// Unfortunately, the vue prop validator does not throw or falls
+			// back to default values on validation failure, therefore, we need
+			// to check for a valid resize limit value
+			return validateLimit( this.resize ) ? this.resize : 'vertical';
+		},
+	},
+} );
+</script>
+
+<style lang="scss">
+	.wikit-TextArea {
+		&__label-wrapper {
+			display: flex;
+			align-items: center;
+			gap: $dimension-spacing-small;
+		}
+
+		&__label {
+			@include Label('block');
+		}
+	}
+
+	.wikit-TextArea__textarea {
+		display: block;
+		width: 100%;
+		// The default resizing behaviour should be on the y axis only
+		resize: vertical;
+
+		/**
+		* Colors
+		*/
+		color: $wikit-Input-color;
+		background-color: $wikit-Input-background-color;
+
+		/**
+		* Typography
+		*/
+		font-family: $wikit-Input-font-family;
+		font-size: $wikit-Input-font-size;
+		font-weight: $wikit-Input-font-weight;
+		line-height: $wikit-Input-line-height;
+
+		/**
+		* Spacing
+		*/
+		padding-inline: $wikit-Input-desktop-padding-inline;
+		padding-block: $wikit-Input-desktop-padding-block;
+
+		@media (max-width: $width-breakpoint-mobile) {
+			padding-inline: $wikit-Input-mobile-padding-inline;
+			padding-block: $wikit-Input-mobile-padding-block;
+		}
+
+		/**
+		* Borders
+		*/
+		border-color: $wikit-Input-border-color;
+		border-style: $wikit-Input-border-style;
+		border-width: $wikit-Input-border-width;
+		border-radius: $wikit-Input-border-radius;
+
+		/**
+		* Animation
+		*/
+		// Sets a basis for the inset box-shadow transition which otherwise doesn't work in Firefox.
+		// https://stackoverflow.com/questions/25410207/css-transition-not-working-on-box-shadow-property/25410897
+		// TODO: replace by token
+		box-shadow: inset 0 0 0 1px transparent;
+		transition-duration: $wikit-Input-transition-duration;
+		transition-timing-function: $wikit-Input-transition-timing-function;
+		transition-property: $wikit-Input-transition-property;
+
+		/**
+		* State overrides
+		*/
+		&:hover {
+			border-color: $wikit-Input-hover-border-color;
+		}
+
+		&:focus,
+		&:active {
+			border-color: $wikit-Input-active-border-color;
+			box-shadow: $wikit-Input-active-box-shadow;
+		}
+
+		&:focus {
+			outline: none;
+		}
+
+		&::placeholder {
+			font-family: $wikit-Input-placeholder-font-family;
+			font-size: $wikit-Input-placeholder-font-size;
+			font-weight: $wikit-Input-placeholder-font-weight;
+			line-height: $wikit-Input-placeholder-line-height;
+			color: $wikit-Input-placeholder-color;
+		}
+
+		/**
+		* Property overrides
+		*/
+		&--horizontal {
+			resize: horizontal;
+		}
+
+		&--none {
+			resize: none;
+		}
+	}
+</style>

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils';
+import TextArea from '@/components/TextArea.vue';
+import { ResizeLimit } from '@/components/ResizeLimit.ts';
+
+describe( 'TextArea.vue', () => {
+	it( 'accepts rows property', () => {
+		const wrapper = mount( TextArea, {
+			propsData: { rows: 42 },
+		} );
+
+		expect( wrapper.props().rows ).toBe( 42 );
+		expect( wrapper.find( 'textarea' ).attributes( 'rows' ) ).toBe( '42' );
+	} );
+
+	it( 'accepts resize property', () => {
+		const wrapper = mount( TextArea, {
+			propsData: { resize: ResizeLimit.Horizontal },
+		} );
+
+		expect( wrapper.props().resize ).toBe( ResizeLimit.Horizontal );
+		expect( wrapper.find( 'textarea' ).classes() ).toContain( 'wikit-TextArea__textarea--horizontal' );
+	} );
+
+	it( 'ignores invalid resize values', () => {
+		expect( () => mount( TextArea, {
+			propsData: { resize: 'nonsense' },
+		} ) ).toThrow( 'Invalid prop: custom validator check failed for prop "resize"' );
+	} );
+
+	it( 'accepts label property', () => {
+		const label = 'da Label';
+		const wrapper = mount( TextArea, {
+			propsData: { label },
+		} );
+
+		expect( wrapper.props().label ).toBe( label );
+		expect( wrapper.find( 'label' ).text() ).toBe( label );
+	} );
+
+	it( 'accepts placeholder property', () => {
+		const placeholder = 'This is a placeholder';
+		const wrapper = mount( TextArea, {
+			propsData: { placeholder },
+		} );
+
+		expect( wrapper.find( 'textarea' ).attributes( 'placeholder' ) ).toBe( placeholder );
+	} );
+
+	it( 'should emit a change event with textarea value', () => {
+		const userInput = 'hello';
+		const wrapper = mount( TextArea );
+
+		wrapper.find( 'textarea' ).setValue( userInput );
+		expect( wrapper.emitted( 'input' )![ 0 ] ).toEqual( [ userInput ] );
+	} );
+} );


### PR DESCRIPTION
_**Note: This PR is marked as a draft as it depends on https://github.com/wmde/wikidata-mismatch-finder/pull/74, which is still pending final approval**_

This change up-streams the basic version of the TextArea component created for the Wikidata Mismatch Finder tool. The basic version of this component includes the label, placeholder, rows and resize props, and implements the default, hover and focus states of the component.

Bug: [T289138](https://phabricator.wikimedia.org/T289138)