### PR TITLE
Add textarea story

### DIFF
--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -15,6 +15,7 @@
 				'wikit-TextArea__textarea',
 				`wikit-TextArea__textarea--${resizeType}`
 			]"
+			:value="value"
 			:rows="rows"
 			:placeholder="placeholder"
 			label=""
@@ -33,6 +34,13 @@ import { ResizeLimit, validateLimit } from '@/components/ResizeLimit';
  */
 export default Vue.extend( {
 	props: {
+		/**
+		 * An initial value for the textarea
+		 */
+		value: {
+			type: String,
+			default: '',
+		},
 		/**
 		 * The text area label
 		 */

--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -28,20 +28,41 @@ import Vue from 'vue';
 import generateId from '@/components/util/generateUid';
 import { ResizeLimit, validateLimit } from '@/components/ResizeLimit';
 
+/**
+ * Text areas are multi-line, non auto-sizing input fields that allow manual resizing by users.
+ */
 export default Vue.extend( {
 	props: {
+		/**
+		 * The text area label
+		 */
 		label: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * The text area placeholder
+		 */
 		placeholder: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * Defines the amount of lines of text that the text area can take by
+		 * default before scroll is triggered, therefore influencing the height
+		 * of the component.
+		 */
 		rows: {
 			type: Number,
 			default: 2,
 		},
+		/**
+		 * Allows users to expand the component horizontally or vertically
+		 * using the expand handler. It can be used to entirely disable manual
+		 * resizing.
+		 *
+		 * Allowed values: `vertical`, `horizontal`,  `none`
+		 */
 		resize: {
 			type: String,
 			validator( value: ResizeLimit ): boolean {

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -32,6 +32,9 @@ basic.args = {
 };
 
 basic.argTypes = {
+    value: {
+        control: false
+    },
     label: {
         control: {
             type: 'text',

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -1,0 +1,69 @@
+import TextArea from '@/components/TextArea';
+import { Component } from 'vue';
+
+export default {
+	component: TextArea,
+	title: 'TextArea',
+};
+
+export function basic( args: object ): Component {
+    return {
+        data(): object {
+            return { args };
+        },
+        components: { TextArea },
+        props: Object.keys( args ),
+        template: `
+			<div style="max-width: 75%">
+				<TextArea 
+                    :label="label"
+                    :placeholder="placeholder"
+                    :rows="rows"
+                    :resize="resize"
+                />
+			</div>
+		`,
+    };
+}
+
+basic.args = {
+    label: 'Label',
+    placeholder: 'Placeholder',
+    resize: 'vertical' 
+};
+
+basic.argTypes = {
+    label: {
+        control: {
+            type: 'text',
+        },
+    },
+    placeholder: {
+        control: {
+            type: 'text',
+        },
+    },
+    rows: {
+        control: {
+            type: 'number',
+        },
+    },
+    resize: {
+        control: {
+            type: 'select',
+            options: ['vertical', 'horizontal', 'none'],
+            default: 'vertical'
+        },
+    },
+};
+
+export function all(): Component {
+	return {
+		components: { TextArea },
+		template: `
+			<div style="max-width: 95%">
+				<TextArea label="Label" placeholder="Placeholder" />
+			</div>
+		`,
+	};
+}

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -28,8 +28,7 @@ export function basic( args: object ): Component {
 
 basic.args = {
     label: 'Label',
-    placeholder: 'Placeholder',
-    resize: 'vertical' 
+    placeholder: 'Placeholder'
 };
 
 basic.argTypes = {
@@ -49,12 +48,25 @@ basic.argTypes = {
         },
     },
     resize: {
+        table: {
+            defaultValue: {
+                summary: 'vertical'
+            }
+        },
         control: {
             type: 'select',
             options: ['vertical', 'horizontal', 'none'],
             default: 'vertical'
         },
     },
+    input : {
+        description: 'Emitted on each character input to the textarea, contains the entire string value of the textarea itself.',
+        table: {
+            type: {
+                summary: 'string'
+            }
+        }
+    }
 };
 
 export function all(): Component {

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -27,6 +27,17 @@ describe( 'TextArea.vue', () => {
 		} ) ).toThrow( 'Invalid prop: custom validator check failed for prop "resize"' );
 	} );
 
+	it( 'accepts a textarea value', () => {
+		const value = 'Some beautiful value!';
+		const wrapper = mount( TextArea, {
+			propsData: { value },
+		} );
+		const element = wrapper.find( 'textarea' ).element as HTMLFormElement;
+
+		expect( wrapper.props().value ).toBe( value );
+		expect( element.value ).toBe( value );
+	} );
+
 	it( 'accepts label property', () => {
 		const label = 'da Label';
 		const wrapper = mount( TextArea, {


### PR DESCRIPTION
_**Note: This PR depends on #459**_

This change adds documentation for the initial text area component, and a story to display it in WiKit's storybook. Additionally, it adds the `value` props to the TextArea component, which was missed (yet unneeded) by the Mismatch Finder implementation.

Bug: [T289141](https://phabricator.wikimedia.org/T289141)