### PR TITLE
TextArea: Add read-only state

### DIFF
--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -19,6 +19,7 @@
 			:value="value"
 			:rows="rows"
 			:placeholder="placeholder"
+			:readonly="readOnly"
 			label=""
 			@input="$emit( 'input', $event.target.value )"
 		/>
@@ -64,6 +65,15 @@ export default Vue.extend( {
 		rows: {
 			type: Number,
 			default: 2,
+		},
+		/**
+		 * Disable users from editing the content of the textarea, while
+		 * still enabling them to focus and interact with the component
+		 * otherwise.
+		 */
+		readOnly: {
+			type: Boolean,
+			default: false,
 		},
 		/**
 		 * Allows users to expand the component horizontally or vertically
@@ -165,6 +175,10 @@ export default Vue.extend( {
 		/**
 		* State overrides
 		*/
+		&[readonly] {
+			background-color: $wikit-Input-read-only-background-color;
+		}
+
 		&:hover {
 			border-color: $wikit-Input-hover-border-color;
 		}

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -9,7 +9,12 @@ export default {
 export function basic( args: object ): Component {
     return {
         data(): object {
-            return { args };
+            return {
+                // Binding to the currentValue prevents the value from resetting
+                // on the re-render when changing the read-only control from
+                // false to true
+                currentValue: ''
+            };
         },
         components: { TextArea },
         props: Object.keys( args ),
@@ -20,6 +25,8 @@ export function basic( args: object ): Component {
                     :placeholder="placeholder"
                     :rows="rows"
                     :resize="resize"
+                    :read-only="readOnly"
+                    v-model="currentValue"
                 />
 			</div>
 		`,
@@ -28,7 +35,9 @@ export function basic( args: object ): Component {
 
 basic.args = {
     label: 'Label',
-    placeholder: 'Placeholder'
+    placeholder: 'Placeholder',
+    resize: 'vertical',
+    readOnly: false
 };
 
 basic.argTypes = {
@@ -48,6 +57,11 @@ basic.argTypes = {
     rows: {
         control: {
             type: 'number',
+        },
+    },
+    readOnly: {
+        control: {
+            type: 'boolean',
         },
     },
     resize: {

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -95,7 +95,7 @@ export function all(): Component {
                     <TextArea label="Default" placeholder="Placeholder" />
                 </div>
                 <div style="max-width: 95%; margin-top: 1em;">
-                    <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" />
+                    <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" value="Potatoes\nArtichokes" />
                 </div>
             </div>
         `,

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -87,12 +87,17 @@ basic.argTypes = {
 };
 
 export function all(): Component {
-	return {
-		components: { TextArea },
-		template: `
-			<div style="max-width: 95%">
-				<TextArea label="Label" placeholder="Placeholder" />
-			</div>
-		`,
-	};
+    return {
+        components: { TextArea },
+        template: `
+            <div>
+                <div style="max-width: 95%;">
+                    <TextArea label="Default" placeholder="Placeholder" />
+                </div>
+                <div style="max-width: 95%; margin-top: 1em;">
+                    <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" />
+                </div>
+            </div>
+        `,
+    };
 }

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -95,7 +95,7 @@ export function all(): Component {
                     <TextArea label="Default" placeholder="Placeholder" />
                 </div>
                 <div style="max-width: 95%; margin-top: 1em;">
-                    <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" value="Potatoes\nArtichokes" />
+                    <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" value="Content within a read-only text area can be selected, but it cannot be edited." />
                 </div>
             </div>
         `,

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -12,6 +12,15 @@ describe( 'TextArea.vue', () => {
 		expect( wrapper.find( 'textarea' ).attributes( 'rows' ) ).toBe( '42' );
 	} );
 
+	it( 'accepts a read-only property', () => {
+		const wrapper = mount( TextArea, {
+			propsData: { readOnly: true },
+		} );
+
+		expect( wrapper.props().readOnly ).toBe( true );
+		expect( wrapper.find( 'textarea' ).attributes( 'readonly' ) ).toBeDefined();
+	} );
+
 	it( 'accepts resize property', () => {
 		const wrapper = mount( TextArea, {
 			propsData: { resize: ResizeLimit.Horizontal },


### PR DESCRIPTION
This change introduces the read-only state to the TextArea component, by implementing the Input component's read only tokens.

Bug: [T290151](https://phabricator.wikimedia.org/T290151)