### PR TITLE
Add ui-text style

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -14,7 +14,7 @@
                 "body-s": {
                     "value": "{font.family.sans.value}"
                 },
-                "label": {
+                "ui-text": {
                     "value": "{font.family.sans.value}"
                 },
                 "placeholder": {
@@ -51,8 +51,11 @@
                 "body-s": {
                     "value": "{font.weight.regular.value}"
                 },
-                "label": {
+                "ui-text": {
                     "value": "{font.weight.regular.value}"
+                },
+                "ui-text-bold": {
+                    "value": "{font.weight.bold.value}"
                 },
                 "placeholder": {
                     "value": "{font.weight.regular.value}"
@@ -73,11 +76,11 @@
                 "body-s": {
                     "value": "{font.line-height.large.value}"
                 },
-                "label": {
+                "ui-text": {
                     "value": "{font.line-height.small.value}"
                 },
                 "placeholder": {
-                    "value": "{font.line-height.medium.value}"
+                    "value": "{font.line-height.small.value}"
                 },
                 "description": {
                     "value": "{font.line-height.large.value}"
@@ -110,7 +113,7 @@
                 "body-s": {
                     "value": "{font.size.small.value}"
                 },
-                "label": {
+                "ui-text": {
                     "value": "{font.size.medium.value}"
                 },
                 "placeholder": {

--- a/tokens/properties/components/Button.json
+++ b/tokens/properties/components/Button.json
@@ -1,16 +1,16 @@
 {
     "wikit-Button": {
         "font-family": {
-            "value": "{font.family.style.label.value}"
+            "value": "{font.family.style.ui-text.value}"
         },
         "font-weight": {
-            "value": "{font.weight.bold.value}"
+            "value": "{font.weight.style.ui-text-bold.value}"
         },
         "font-size": {
-            "value": "{font.size.style.label.value}"
+            "value": "{font.size.style.ui-text.value}"
         },
         "line-height": {
-            "value": "{font.line-height.style.label.value}"
+            "value": "{font.line-height.style.ui-text.value}"
         },
         "border-width": {
             "value": "{border.width.thin.value}"

--- a/tokens/properties/components/Dropdown.json
+++ b/tokens/properties/components/Dropdown.json
@@ -17,16 +17,16 @@
         },
         "selected-option": {
             "font-family": {
-                "value": "{font.family.style.label.value}"
+                "value": "{font.family.style.ui-text.value}"
             },
             "font-size": {
-                "value": "{font.size.style.label.value}"
+                "value": "{font.size.style.ui-text.value}"
             },
             "font-weight": {
-                "value": "{font.weight.bold.value}"
+                "value": "{font.weight.style.ui-text-bold.value}"
             },
             "line-height": {
-                "value": "{font.line-height.style.label.value}"
+                "value": "{font.line-height.style.ui-text.value}"
             },
             "color": {
                 "value": "{font.color.base.value}"
@@ -34,16 +34,16 @@
         },
         "placeholder": {
             "font-family": {
-                "value": "{font.family.style.label.value}"
+                "value": "{font.family.style.ui-text.value}"
             },
             "font-size": {
-                "value": "{font.size.style.label.value}"
+                "value": "{font.size.style.ui-text.value}"
             },
             "font-weight": {
-                "value": "{font.weight.bold.value}"
+                "value": "{font.weight.style.ui-text-bold.value}"
             },
             "line-height": {
-                "value": "{font.line-height.style.label.value}"
+                "value": "{font.line-height.style.ui-text.value}"
             },
             "color": {
                 "value": "{font.color.base.value}"

--- a/tokens/properties/components/Input.json
+++ b/tokens/properties/components/Input.json
@@ -16,16 +16,16 @@
             "value": "{background.color.base.default.value}"
         },
         "font-family": {
-            "value": "{font.family.style.body.value}"
+            "value": "{font.family.style.ui-text.value}"
         },
         "font-size": {
-            "value": "{font.size.style.body.value}"
+            "value": "{font.size.style.ui-text.value}"
         },
         "font-weight": {
-            "value": "{font.weight.style.body.value}"
+            "value": "{font.weight.style.ui-text.value}"
         },
         "line-height": {
-            "value": "{font.line-height.small.value}"
+            "value": "{font.line-height.style.ui-text.value}"
         },
         "color": {
             "value": "{font.color.base.value}"

--- a/tokens/properties/components/InputExtender.json
+++ b/tokens/properties/components/InputExtender.json
@@ -41,16 +41,16 @@
                 }
             },
             "font-family": {
-                "value": "{font.family.style.label.value}"
+                "value": "{font.family.style.ui-text.value}"
             },
             "font-size": {
-                "value": "{font.size.style.label.value}"
+                "value": "{font.size.style.ui-text.value}"
             },
             "font-weight": {
-                "value": "{font.weight.style.label.value}"
+                "value": "{font.weight.style.ui-text.value}"
             },
             "line-height": {
-                "value": "{font.line-height.style.label.value}"
+                "value": "{font.line-height.style.ui-text.value}"
             },
             "color": {
                 "value": "{font.color.base.value}"

--- a/tokens/properties/components/OptionsMenu.json
+++ b/tokens/properties/components/OptionsMenu.json
@@ -1,163 +1,163 @@
 {
-	"wikit-OptionsMenu": {
-		"background-color": {
-			"value": "{background.color.base.default.value}"
-		},
-		"border": {
-			"style": {
-				"value": "{border.style.base.value}"
-			},
-			"width": {
-				"value": "{border.width.thin.value}"
-			},
-			"radius": {
-				"value": "{border.radius.base.value}"
-			},
-			"color": {
-				"value": "{border.color.base.default.value}"
-			}
-		},
-		"min-width": {
-			"value": "{dimension.width.full.value}"
-		},
-		"max-width": {
-			"value": "{dimension.width.double.value}"
-		},
-		"box-shadow": {
-			"value": "{box-shadow.elevation.menu.value}"
-		},
-		"item": {
-			"padding-vertical": {
-				"value": "{dimension.spacing.small.value}"
-			},
-			"padding-horizontal": {
-				"value": "{dimension.spacing.medium.value}"
-			},
-			"hover": {
-				"background-color": {
-					"value": "{background.color.base.hover.value}"
-				}
-			},
-			"active": {
-				"color": {
-					"value": "{font.color.progressive.value}"
-				},
-				"background-color": {
-					"value": "{background.color.base.active.value}"
-				}
-			},
-			"selected": {
-				"color": {
-					"value": "{font.color.base.value}"
-				},
-				"background-color": {
-					"value": "{background.color.base.active.value}"
-				}
-			},
-			"selected-hover": {
-				"color": {
-					"value": "{font.color.progressive.value}"
-				}
-			},
-			"disabled": {
-				"color": {
-					"value": "{font.color.disabled.value}"
-				},
-				"background-color": {
-					"value": "{background.color.base.default.value}"
-				}
-			},
-			"transition-duration": {
-				"value": "{transition.interaction.menu.duration.value}"
-			},
-			"transition-property": {
-				"value": "{transition.interaction.menu.property.value}"
-			},
-			"transition-timing-function": {
-				"value": "{transition.timing-function.ease.value}"
-			},
-			"label": {
-				"font-family": {
-					"value": "{font.family.style.label.value}"
-				},
-				"font-size": {
-					"value": "{font.size.style.label.value}"
-				},
-				"font-weight": {
-					"regular": {
-						"value": "{font.weight.style.label.value}"
-					},
-					"bold": {
-						"value": "{font.weight.bold.value}"
-					}
-				},
-				"line-height": {
-					"value": "{font.line-height.style.label.value}"
-				},
-				"font-color": {
-					"value": "{font.color.base.value}"
-				}
-			},
-			"description": {
-				"font-family": {
-					"value": "{font.family.style.description.value}"
-				},
-				"font-size": {
-					"value": "{font.size.style.description.value}"
-				},
-				"font-weight": {
-					"value": "{font.weight.style.description.value}"
-				},
-				"line-height": {
-					"value": "{font.line-height.small.value}"
-				},
-				"font-color": {
-					"value": "{font.color.base.value}"
-				}
-			},
-			"tag": {
-				"font-family": {
-					"value": "{font.family.style.label.value}"
-				},
-				"font-size": {
-					"value": "{font.size.style.label.value}"
-				},
-				"font-weight": {
-					"value": "{font.weight.style.label.value}"
-				},
-				"line-height": {
-					"value": "{font.line-height.style.label.value}"
-				},
-				"font-color": {
-					"value": "{font.color.base.value}"
-				},
-				"left-spacing": {
-					"value": "{dimension.spacing.small.value}"
-				}
-			}
-		},
-		"no-results": {
-			"padding-vertical": {
-				"value": "{dimension.spacing.small.value}"
-			},
-			"padding-horizontal": {
-				"value": "{dimension.spacing.medium.value}"
-			},
-			"font-family": {
-				"value": "{font.family.style.label.value}"
-			},
-			"font-size": {
-				"value": "{font.size.style.label.value}"
-			},
-			"font-weight": {
-				"value": "{font.weight.style.label.value}"
-			},
-			"line-height": {
-				"value": "{font.line-height.style.label.value}"
-			},
-			"font-color": {
-				"value": "{font.color.subtle.value}"
-			}
-		}
-	}
+    "wikit-OptionsMenu": {
+        "background-color": {
+            "value": "{background.color.base.default.value}"
+        },
+        "border": {
+            "style": {
+                "value": "{border.style.base.value}"
+            },
+            "width": {
+                "value": "{border.width.thin.value}"
+            },
+            "radius": {
+                "value": "{border.radius.base.value}"
+            },
+            "color": {
+                "value": "{border.color.base.default.value}"
+            }
+        },
+        "min-width": {
+            "value": "{dimension.width.full.value}"
+        },
+        "max-width": {
+            "value": "{dimension.width.double.value}"
+        },
+        "box-shadow": {
+            "value": "{box-shadow.elevation.menu.value}"
+        },
+        "item": {
+            "padding-vertical": {
+                "value": "{dimension.spacing.small.value}"
+            },
+            "padding-horizontal": {
+                "value": "{dimension.spacing.medium.value}"
+            },
+            "hover": {
+                "background-color": {
+                    "value": "{background.color.base.hover.value}"
+                }
+            },
+            "active": {
+                "color": {
+                    "value": "{font.color.progressive.value}"
+                },
+                "background-color": {
+                    "value": "{background.color.base.active.value}"
+                }
+            },
+            "selected": {
+                "color": {
+                    "value": "{font.color.base.value}"
+                },
+                "background-color": {
+                    "value": "{background.color.base.active.value}"
+                }
+            },
+            "selected-hover": {
+                "color": {
+                    "value": "{font.color.progressive.value}"
+                }
+            },
+            "disabled": {
+                "color": {
+                    "value": "{font.color.disabled.value}"
+                },
+                "background-color": {
+                    "value": "{background.color.base.default.value}"
+                }
+            },
+            "transition-duration": {
+                "value": "{transition.interaction.menu.duration.value}"
+            },
+            "transition-property": {
+                "value": "{transition.interaction.menu.property.value}"
+            },
+            "transition-timing-function": {
+                "value": "{transition.timing-function.ease.value}"
+            },
+            "label": {
+                "font-family": {
+                    "value": "{font.family.style.ui-text.value}"
+                },
+                "font-size": {
+                    "value": "{font.size.style.ui-text.value}"
+                },
+                "font-weight": {
+                    "regular": {
+                        "value": "{font.weight.style.ui-text.value}"
+                    },
+                    "bold": {
+                        "value": "{font.weight.style.ui-text-bold.value}"
+                    }
+                },
+                "line-height": {
+                    "value": "{font.line-height.style.ui-text.value}"
+                },
+                "font-color": {
+                    "value": "{font.color.base.value}"
+                }
+            },
+            "description": {
+                "font-family": {
+                    "value": "{font.family.style.description.value}"
+                },
+                "font-size": {
+                    "value": "{font.size.style.description.value}"
+                },
+                "font-weight": {
+                    "value": "{font.weight.style.description.value}"
+                },
+                "line-height": {
+                    "value": "{font.line-height.small.value}"
+                },
+                "font-color": {
+                    "value": "{font.color.base.value}"
+                }
+            },
+            "tag": {
+                "font-family": {
+                    "value": "{font.family.style.ui-text.value}"
+                },
+                "font-size": {
+                    "value": "{font.size.style.ui-text.value}"
+                },
+                "font-weight": {
+                    "value": "{font.weight.style.ui-text.value}"
+                },
+                "line-height": {
+                    "value": "{font.line-height.style.ui-text.value}"
+                },
+                "font-color": {
+                    "value": "{font.color.base.value}"
+                },
+                "left-spacing": {
+                    "value": "{dimension.spacing.small.value}"
+                }
+            }
+        },
+        "no-results": {
+            "padding-vertical": {
+                "value": "{dimension.spacing.small.value}"
+            },
+            "padding-horizontal": {
+                "value": "{dimension.spacing.medium.value}"
+            },
+            "font-family": {
+                "value": "{font.family.style.ui-text.value}"
+            },
+            "font-size": {
+                "value": "{font.size.style.ui-text.value}"
+            },
+            "font-weight": {
+                "value": "{font.weight.style.ui-text.value}"
+            },
+            "line-height": {
+                "value": "{font.line-height.style.ui-text.value}"
+            },
+            "font-color": {
+                "value": "{font.color.subtle.value}"
+            }
+        }
+    }
 }

--- a/tokens/properties/components/Popover.json
+++ b/tokens/properties/components/Popover.json
@@ -4,13 +4,13 @@
             "value": "{font.color.base.value}"
         },
         "font-family": {
-            "value": "{font.family.style.body.value}"
+            "value": "{font.family.style.body-s.value}"
         },
         "font-size": {
             "value": "{font.size.style.body-s.value}"
         },
         "font-weight": {
-            "value": "{font.weight.style.body.value}"
+            "value": "{font.weight.style.body-s.value}"
         },
         "line-height": {
             "value": "{font.line-height.style.body-s.value}"
@@ -41,7 +41,7 @@
         },
         "transition": {
             "delay": {
-                "value":"{transition.duration.fast.value}",
+                "value": "{transition.duration.fast.value}",
                 "comment": "Show and hide delays"
             }
         },
@@ -49,7 +49,7 @@
             "value": "{dimension.spacing.xsmall.value}",
             "comment": "Aka distance. This refers to the space between the target and the popover pointer. Better names welcome"
         },
-        "pointer":  {
+        "pointer": {
             "width": {
                 "value": "{dimension.spacing.large.value}"
             },

--- a/tokens/properties/components/ToggleButton.json
+++ b/tokens/properties/components/ToggleButton.json
@@ -4,16 +4,16 @@
             "value": "{font.color.base.value}"
         },
         "font-family": {
-            "value": "{font.family.style.label.value}"
+            "value": "{font.family.style.ui-text.value}"
         },
         "font-weight": {
-            "value": "{font.weight.bold.value}"
+            "value": "{font.weight.style.ui-text-bold.value}"
         },
         "font-size": {
-            "value": "{font.size.style.label.value}"
+            "value": "{font.size.style.ui-text.value}"
         },
         "line-height": {
-            "value": "{font.line-height.style.label.value}"
+            "value": "{font.line-height.style.ui-text.value}"
         },
         "border-width": {
             "value": "{border.width.thin.value}"

--- a/tokens/properties/components/ValidationMessage.json
+++ b/tokens/properties/components/ValidationMessage.json
@@ -4,16 +4,16 @@
             "value": "{dimension.spacing.xsmall.value}"
         },
         "font-family": {
-            "value": "{font.family.style.body.value}"
+            "value": "{font.family.style.ui-text.value}"
         },
         "font-size": {
-            "value": "{font.size.style.body.value}"
+            "value": "{font.size.style.ui-text.value}"
         },
         "font-weight": {
-            "value": "{font.weight.style.body.value}"
+            "value": "{font.weight.style.ui-text.value}"
         },
         "line-height": {
-            "value": "{font.line-height.small.value}"
+            "value": "{font.line-height.style.ui-text.value}"
         },
         "error": {
             "color": {

--- a/tokens/properties/mixins/Label.json
+++ b/tokens/properties/mixins/Label.json
@@ -7,16 +7,16 @@
             "value": "{font.color.disabled.value}"
         },
         "font-family": {
-            "value": "{font.family.style.label.value}"
+            "value": "{font.family.style.ui-text.value}"
         },
         "font-size": {
-            "value": "{font.size.style.label.value}"
+            "value": "{font.size.style.ui-text.value}"
         },
         "font-weight": {
-            "value": "{font.weight.style.label.value}"
+            "value": "{font.weight.style.ui-text.value}"
         },
         "line-height": {
-            "value": "{font.line-height.style.label.value}"
+            "value": "{font.line-height.style.ui-text.value}"
         },
         "padding-block-end": {
             "value": "{dimension.spacing.xsmall.value}"


### PR DESCRIPTION
The Body typographic style is devised to style denser chunks of text (e.g. messages, dialog content, paragraphs) and its style (bigger line-height) is optimized to improve readability in those contexts. On the other hand, labels have a specific meaning in information architecture: these are text components that aim at communicating information in a concise and efficient way that takes the least possible amount of space in a UI.

Neither the body style nor the label nomenclature apply to the text within components: UI text tries to be the default style that covers those instances in which a component could contain (potentially) a bigger amount of text (e.g. inline messages, user input in a text area or table content).

This PR introduces the new ui-text typographic style, and conveniently applies it to the components that currently need it, such as validation messages, dropdown, label and input.