### PR TITLE
TextArea: Add loading state

### DIFF
--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -10,19 +10,22 @@
 				{{ label }}
 			</label>
 		</span>
-		<textarea
-			:id="id"
-			:class="[
-				'wikit-TextArea__textarea',
-				`wikit-TextArea__textarea--${resizeType}`
-			]"
-			:value="value"
-			:rows="rows"
-			:placeholder="placeholder"
-			:readonly="readOnly"
-			label=""
-			@input="$emit( 'input', $event.target.value )"
-		/>
+		<div class="wikit-TextArea__textarea-wrapper">
+			<div class="wikit-TextArea__progress" v-if="loading" role="progressbar" />
+			<textarea
+				:id="id"
+				:class="[
+					'wikit-TextArea__textarea',
+					`wikit-TextArea__textarea--${resizeType}`
+				]"
+				:value="value"
+				:rows="rows"
+				:placeholder="placeholder"
+				:readonly="readOnly || loading"
+				label=""
+				@input="$emit( 'input', $event.target.value )"
+			/>
+		</div>
 	</div>
 </template>
 
@@ -89,6 +92,14 @@ export default Vue.extend( {
 			},
 			default: ResizeLimit.Vertical,
 		},
+		/**
+		 * Sets the textarea to loading mode, which displays an indeterminate
+		 * progress bar and sets the component to readonly mode.
+		 */
+		loading: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -119,6 +130,21 @@ export default Vue.extend( {
 
 		&__label {
 			@include Label('block');
+		}
+
+		&__textarea-wrapper {
+			position: relative;
+			overflow: hidden;
+		}
+
+		&__progress {
+			@include InlineProgressBar;
+
+			&[role=progressbar] {
+				position: absolute;
+				inset-block-start: 0;
+				inset-inline-start: 0;
+			}
 		}
 	}
 

--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -149,6 +149,7 @@ export default Vue.extend( {
 	}
 
 	.wikit-TextArea__textarea {
+		box-sizing: border-box;
 		display: block;
 		width: 100%;
 		// The default resizing behaviour should be on the y axis only

--- a/vue-components/src/styles/main.scss
+++ b/vue-components/src/styles/main.scss
@@ -2,3 +2,4 @@
 @import '~@wmde/wikit-tokens/dist/variables';
 @import './mixins/Label';
 @import './mixins/Link';
+@import './mixins/InlineProgressBar';

--- a/vue-components/src/styles/mixins/InlineProgressBar.scss
+++ b/vue-components/src/styles/mixins/InlineProgressBar.scss
@@ -1,0 +1,40 @@
+// Currently the inline progress bar only supports indeterminate loading mode.
+// For a proof of concept on how this can include also determinate loading, see:
+// https://codepen.io/xumium/pen/LYLZbva?editors=1100
+@mixin InlineProgressBar {
+    // We ensure semantic usage by only targeting generic elements that set the
+    // correct role 
+    &[role="progressbar"] { 
+        position: relative;
+        width: $wikit-InlineProgressBar-track-width;
+        height: $wikit-InlineProgressBar-track-height;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            display: block;
+            height: 100%;
+            background: $wikit-InlineProgressBar-background-color;
+        }
+
+        // Indeterminate progress bars should not set the `aria-valuenow` 
+        // attribute
+        &:not([aria-valuenow])::before {
+            width: 20%;
+            border-radius: $wikit-InlineProgressBar-indeterminate-border-radius;
+            animation-name: load-indeterminate;
+            animation-duration: $wikit-InlineProgressBar-animation-duration;
+            animation-timing-function: ease;
+            animation-iteration-count: infinite;
+            animation-delay: 0s;
+        }
+    }
+
+    @keyframes load-indeterminate {
+        0% { left: 0; }
+        50% { left: 80%; }
+        100% { left: 0; }
+    }
+}

--- a/vue-components/src/styles/mixins/InlineProgressBar.scss
+++ b/vue-components/src/styles/mixins/InlineProgressBar.scss
@@ -4,10 +4,10 @@
 @mixin InlineProgressBar {
     // We ensure semantic usage by only targeting generic elements that set the
     // correct role 
-    &[role="progressbar"] { 
+    &[role=progressbar] {
         position: relative;
-        width: $wikit-InlineProgressBar-track-width;
-        height: $wikit-InlineProgressBar-track-height;
+        width: $wikit-Progress-inline-track-width;
+        height: $wikit-Progress-inline-track-height;
 
         &::before {
             content: '';
@@ -16,16 +16,16 @@
             left: 0;
             display: block;
             height: 100%;
-            background: $wikit-InlineProgressBar-background-color;
+            background: $wikit-Progress-inline-background-color;
         }
 
         // Indeterminate progress bars should not set the `aria-valuenow` 
         // attribute
         &:not([aria-valuenow])::before {
             width: 20%;
-            border-radius: $wikit-InlineProgressBar-indeterminate-border-radius;
+            border-radius: $wikit-Progress-inline-indeterminate-border-radius;
             animation-name: load-indeterminate;
-            animation-duration: $wikit-InlineProgressBar-animation-duration;
+            animation-duration: $wikit-Progress-inline-animation-duration;
             animation-timing-function: ease;
             animation-iteration-count: infinite;
             animation-delay: 0s;

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -26,6 +26,7 @@ export function basic( args: object ): Component {
                     :rows="rows"
                     :resize="resize"
                     :read-only="readOnly"
+                    :loading="loading"
                     v-model="currentValue"
                 />
 			</div>
@@ -37,7 +38,8 @@ basic.args = {
     label: 'Label',
     placeholder: 'Placeholder',
     resize: 'vertical',
-    readOnly: false
+    readOnly: false,
+    loading: false
 };
 
 basic.argTypes = {
@@ -53,6 +55,11 @@ basic.argTypes = {
         control: {
             type: 'text',
         },
+    },
+    loading: {
+        control: {
+            type: 'boolean',
+        }
     },
     rows: {
         control: {

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -104,6 +104,9 @@ export function all(): Component {
                 <div style="max-width: 95%; margin-top: 1em;">
                     <TextArea label="Read Only" placeholder="Placeholder" :read-only="true" value="Content within a read-only text area can be selected, but it cannot be edited." />
                 </div>
+                <div style="max-width: 95%; margin-top: 1em;">
+                    <TextArea label="Loading" placeholder="Placeholder" :loading="true" value="When the text area is set to loading, an indeterminate progress bar will appear." />
+                </div>
             </div>
         `,
     };

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -72,6 +72,26 @@ describe( 'TextArea.vue', () => {
 		expect( wrapper.find( 'textarea' ).attributes( 'placeholder' ) ).toBe( placeholder );
 	} );
 
+	it( 'accepts loading property', () => {
+		const loading = true;
+		const wrapper = mount( TextArea, {
+			propsData: { loading },
+		} );
+
+		expect( wrapper.props().loading ).toBe( loading );
+		expect( wrapper.find( '.wikit-TextArea__progress' ).exists() ).toBe( true );
+		expect( wrapper.find( 'textarea' ).attributes( 'readonly' ) ).toBeDefined();
+	} );
+
+	it( 'does not render progress bar when loading is set to false', () => {
+		const loading = false;
+		const wrapper = mount( TextArea, {
+			propsData: { loading },
+		} );
+
+		expect( wrapper.find( '.wikit-TextArea__progress' ).exists() ).toBe( false );
+	} );
+
 	it( 'should emit a change event with textarea value', () => {
 		const userInput = 'hello';
 		const wrapper = mount( TextArea );


### PR DESCRIPTION
This change adds the loading state to the TextArea component. Additionally, an issue where the textarea element was overflowing its container was discovered and fixed.

Bug: [T290151](https://phabricator.wikimedia.org/T290151)