### PR TITLE
Add TextArea warning and error states

### DIFF
--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -16,7 +16,8 @@
 				:id="id"
 				:class="[
 					'wikit-TextArea__textarea',
-					`wikit-TextArea__textarea--${resizeType}`
+					`wikit-TextArea__textarea--${resizeType}`,
+					{ [ `wikit-TextArea__textarea--${feedback}` ]: feedback }
 				]"
 				:value="value"
 				:rows="rows"
@@ -26,18 +27,36 @@
 				@input="$emit( 'input', $event.target.value )"
 			/>
 		</div>
+		<ValidationMessage
+			v-if="error"
+			:type="error.type"
+			:message="error.message"
+		/>
 	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import generateId from '@/components/util/generateUid';
+import VueCompositionAPI, { defineComponent, computed } from '@vue/composition-api';
+
+import ValidationMessage from './ValidationMessage.vue';
 import { ResizeLimit, validateLimit } from '@/components/ResizeLimit';
+import generateId from '@/components/util/generateUid';
+import { errorProp, ErrorProp, getFeedbackTypeFromProps } from '@/compositions/validatable';
+
+Vue.use( VueCompositionAPI );
 
 /**
  * Text areas are multi-line, non auto-sizing input fields that allow manual resizing by users.
  */
-export default Vue.extend( {
+export default defineComponent( {
+	name: 'TextArea',
+	components: { ValidationMessage },
+	setup( props: { error: ErrorProp } ) {
+		return {
+			feedback: computed( getFeedbackTypeFromProps( props ) ),
+		};
+	},
 	props: {
 		/**
 		 * An initial value for the textarea
@@ -60,6 +79,12 @@ export default Vue.extend( {
 			type: String,
 			default: '',
 		},
+		/**
+		 * Any validation message that should be displayed with the
+		 * component. Accepts an object with a `type` (error | warning) and
+		 * a `message`.
+		 */
+		error: errorProp,
 		/**
 		 * Defines the amount of lines of text that the text area can take by
 		 * default before scroll is triggered, therefore influencing the height
@@ -193,7 +218,6 @@ export default Vue.extend( {
 		*/
 		// Sets a basis for the inset box-shadow transition which otherwise doesn't work in Firefox.
 		// https://stackoverflow.com/questions/25410207/css-transition-not-working-on-box-shadow-property/25410897
-		// TODO: replace by token
 		box-shadow: inset 0 0 0 1px transparent;
 		transition-duration: $wikit-Input-transition-duration;
 		transition-timing-function: $wikit-Input-transition-timing-function;
@@ -237,6 +261,37 @@ export default Vue.extend( {
 
 		&--none {
 			resize: none;
+		}
+
+		/**
+		 * Validation overrides
+		 */
+		&--error {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				border-color: $wikit-Input-error-border-color;
+			}
+
+			&:focus,
+			&:active {
+				box-shadow: $wikit-Input-error-active-box-shadow;
+			}
+		}
+
+		&--warning {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				border-color: $wikit-Input-warning-border-color;
+			}
+
+			&:focus,
+			&:active {
+				box-shadow: $wikit-Input-warning-active-box-shadow;
+			}
 		}
 	}
 </style>

--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -264,8 +264,8 @@ export default defineComponent( {
 		}
 
 		/**
-		 * Validation overrides
-		 */
+		* Validation overrides
+		*/
 		&--error {
 			&,
 			&:hover,

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -144,7 +144,7 @@ export function all(): Component {
                     <TextArea label="Warning" :error="{ type: 'warning', message: 'Warnings should appear underneath the text area, as long as they are passed to the component.' }" value="To set a warning message for the text area, pass an object with the type: 'warning' along with a message to the 'error' prop." />
                 </div>
                 <div style="max-width: 95%; margin-top: 1em;">
-                    <TextArea label="Warning" :error="{ type: 'error', message: 'Errors should appear underneath the text area, as long as they are passed to the component.' }" value="To set an error message for the text area, pass an object with the type: 'error' along with a message to the 'error' prop." />
+                    <TextArea label="Error" :error="{ type: 'error', message: 'Errors should appear underneath the text area, as long as they are passed to the component.' }" value="To set an error message for the text area, pass an object with the type: 'error' along with a message to the 'error' prop." />
                 </div>
             </div>
         `,

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -27,10 +27,30 @@ export function basic( args: object ): Component {
                     :resize="resize"
                     :read-only="readOnly"
                     :loading="loading"
+                    :error="validation"
                     v-model="currentValue"
                 />
 			</div>
 		`,
+        computed: {
+            validation(): string {
+                // To enable preview of validation states, we add this computed
+                // property and bind it to the component's error prop
+                const mapping = {
+                    'none': null,
+                    'warning': {
+                        type: 'warning',
+                        message: 'This is a warning message'
+                    },
+                    'error': {
+                        type: 'error',
+                        message: 'This is an error message'
+                    }
+                }
+
+                return mapping[this.error];
+            },
+        }
     };
 }
 
@@ -39,12 +59,25 @@ basic.args = {
     placeholder: 'Placeholder',
     resize: 'vertical',
     readOnly: false,
-    loading: false
+    loading: false,
+    error: 'none'
 };
 
 basic.argTypes = {
     value: {
         control: false
+    },
+    error: {
+        control: {
+            type: 'select',
+            options: ['none', 'warning', 'error'],
+            default: 'none'
+        },
+        table: {
+            type: {
+                summary: 'object'
+            }
+        }
     },
     label: {
         control: {
@@ -106,6 +139,12 @@ export function all(): Component {
                 </div>
                 <div style="max-width: 95%; margin-top: 1em;">
                     <TextArea label="Loading" placeholder="Placeholder" :loading="true" value="When the text area is set to loading, an indeterminate progress bar will appear." />
+                </div>
+                <div style="max-width: 95%; margin-top: 1em;">
+                    <TextArea label="Warning" :error="{ type: 'warning', message: 'Warnings should appear underneath the text area, as long as they are passed to the component.' }" value="To set a warning message for the text area, pass an object with the type: 'warning' along with a message to the 'error' prop." />
+                </div>
+                <div style="max-width: 95%; margin-top: 1em;">
+                    <TextArea label="Warning" :error="{ type: 'error', message: 'Errors should appear underneath the text area, as long as they are passed to the component.' }" value="To set an error message for the text area, pass an object with the type: 'error' along with a message to the 'error' prop." />
                 </div>
             </div>
         `,

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import TextArea from '@/components/TextArea.vue';
+import ValidationMessage from '@/components/ValidationMessage.vue';
 import { ResizeLimit } from '@/components/ResizeLimit.ts';
 
 describe( 'TextArea.vue', () => {
@@ -61,6 +62,29 @@ describe( 'TextArea.vue', () => {
 
 		expect( wrapper.props().label ).toBe( label );
 		expect( wrapper.find( 'label' ).text() ).toBe( label );
+	} );
+
+	it( 'accepts an error prop', () => {
+		const validation = {
+			type: 'warning',
+			message: 'things don\'t work'
+		}
+
+		const wrapper = mount( TextArea, {
+			propsData: { error: validation },
+		} );
+
+		const validationMessage = wrapper.findComponent( ValidationMessage );
+
+		expect( wrapper.props().error ).toBe( validation );
+		expect( validationMessage.props( 'message' ) ).toBe( validation.message );
+		expect( validationMessage.props( 'type' ) ).toBe( validation.type );
+	} );
+
+	it( 'does not render validation message when error is not set', () => {
+		const wrapper = mount( TextArea );
+
+		expect( wrapper.findComponent( ValidationMessage ).exists() ).toBe( false );
 	} );
 
 	it( 'accepts placeholder property', () => {

--- a/vue-components/tests/unit/components/TextArea.spec.ts
+++ b/vue-components/tests/unit/components/TextArea.spec.ts
@@ -67,8 +67,8 @@ describe( 'TextArea.vue', () => {
 	it( 'accepts an error prop', () => {
 		const validation = {
 			type: 'warning',
-			message: 'things don\'t work'
-		}
+			message: 'things don\'t work',
+		};
 
 		const wrapper = mount( TextArea, {
 			propsData: { error: validation },


### PR DESCRIPTION
This change enables validation states in the TextArea Component.

Bug: [T290167](https://phabricator.wikimedia.org/T290167)