### PR TITLE
Adjust indeterminate inline loader width to reduce its speed

### DIFF
--- a/vue-components/src/styles/mixins/InlineProgressBar.scss
+++ b/vue-components/src/styles/mixins/InlineProgressBar.scss
@@ -22,7 +22,7 @@
         // Indeterminate progress bars should not set the `aria-valuenow` 
         // attribute
         &:not([aria-valuenow])::before {
-            width: 20%;
+            width: 30%;
             border-radius: $wikit-Progress-inline-indeterminate-border-radius;
             animation-name: load-indeterminate;
             animation-duration: $wikit-Progress-inline-animation-duration;
@@ -34,7 +34,7 @@
 
     @keyframes load-indeterminate {
         0% { left: 0; }
-        50% { left: 80%; }
+        50% { left: 70%; }
         100% { left: 0; }
     }
 }


### PR DESCRIPTION
Tiny change to reduce the speed of the inline indeterminate loader and get it closer to the [WMF live demo example.](https://di-searchland-2.web.app/)

Related but not a blocker to [T290151](https://phabricator.wikimedia.org/T290151).