### PR TITLE
Pre release v2.1.0 alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ development)_
 
 ## [Unreleased]
 
+### Added
+
 - New TextArea Component
+- New Table Component
+
+### Changed
+
 - Dimension-layout tokens are now based on _rem_ instead of _em_
 
 ## [2.0.0] - 19.07.2021

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-docs",
-	"version": "2.1.0-alpha.3",
+	"version": "2.1.0-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "2.1.0-alpha.3",
+  "version": "2.1.0-alpha.4",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist -s src/00-doc/static"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^2.1.0-alpha.3",
-    "@wmde/wikit-vue-components": "^2.1.0-alpha.3",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.4",
+    "@wmde/wikit-vue-components": "^2.1.0-alpha.4",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "2.1.0-alpha.3"
+  "version": "2.1.0-alpha.4"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-tokens",
-	"version": "2.1.0-alpha.3",
+	"version": "2.1.0-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.3",
+  "version": "2.1.0-alpha.4",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-vue-components",
-	"version": "2.1.0-alpha.3",
+	"version": "2.1.0-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "2.1.0-alpha.3",
+  "version": "2.1.0-alpha.4",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -35,7 +35,7 @@
   "types": "dist/main.d.ts",
   "dependencies": {
     "@vue/composition-api": "^1.0.0-beta.20",
-    "@wmde/wikit-tokens": "^2.1.0-alpha.3",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.4",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
This change adds the table component to the change log, and bumps the prerelease version to `2.1.0-alpha.4`.

Bug: [T291078](https://phabricator.wikimedia.org/T291078)