### PR TITLE
vue-components: Add slots for icons in Button.vue

### DIFF
--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -9,7 +9,21 @@
 		]"
 		:type="nativeType"
 	>
-		<slot />
+		<div class="wikit-Button--content">
+			<!-- @slot Use this slot to pass an icon to appear before the label-->
+			<slot name="prefix" />
+			<div
+				:class="[
+					hasPrefixSlot ? `wikit-Button--content--start` : '',
+					hasSuffixSlot ? `wikit-Button--content--end` : '',
+				]"
+			>
+				<!-- @slot Default slot for label-->
+				<slot />
+			</div>
+			<!-- @slot Use this slot to pass an icon to appear after the label-->
+			<slot name="suffix" />
+		</div>
 	</button>
 </template>
 
@@ -76,6 +90,14 @@ export default defineComponent( {
 			default: 'button',
 		},
 	},
+	computed: {
+		hasPrefixSlot(): boolean {
+			return !!this.$slots.prefix;
+		},
+		hasSuffixSlot(): boolean {
+			return !!this.$slots.suffix;
+		},
+	},
 	setup( props: {
 		type: 'neutral' | 'progressive' | 'destructive';
 		variant: 'normal' | 'primary' | 'quiet';
@@ -114,6 +136,18 @@ $base: '.wikit-Button';
 	transition-timing-function: $wikit-Button-transition-timing-function;
 	transition-property: $wikit-Button-transition-property;
 	white-space: nowrap;
+
+	#{$base}--content {
+		display: flex; // aligns the slots content inside the button, e.g. an icon and label
+	}
+
+	#{$base}--content--start {
+		padding-inline-start: $dimension-spacing-small;
+	}
+
+	#{$base}--content--end {
+		padding-inline-end: $dimension-spacing-small;
+	}
 
 	// TODO use breakpoint mixin?
 	@media (max-width: $width-breakpoint-mobile) {

--- a/vue-components/stories/Button.stories.ts
+++ b/vue-components/stories/Button.stories.ts
@@ -9,13 +9,29 @@ export default {
 
 export function normal(): Component {
 	return {
-		components: { Button },
+		components: { Button, Icon },
 		// The normal button types are all in the same story to achieve high % of visual tests coverage.
 		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
 		template: `
 			<div>
-				<Button>Neutral</Button>
-				<Button disabled>Disabled</Button>
+				<div style="margin-bottom:16px;">
+					<Button>Neutral</Button>
+					<Button disabled>Disabled</Button>
+				</div>
+				<div>
+					<Button>
+						<template #prefix>
+							<Icon type="alert" size="medium" color="inherit"/>
+						</template>
+						Neutral
+					</Button>
+					<Button disabled>
+						<template #prefix>
+								<Icon type="edit" size="medium" color="inherit"/>
+						</template>
+						Disabled
+					</Button>
+				</div>
 			</div>
 		`,
 	};
@@ -23,14 +39,36 @@ export function normal(): Component {
 
 export function primary(): Component {
 	return {
-		components: { Button },
+		components: { Button, Icon },
 		// The primary button types are all in the same story to achieve high % of visual tests coverage.
 		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
 		template: `
 			<div>
-				<Button variant="primary" type="progressive">Primary progressive</Button>
-				<Button variant="primary" type="destructive">Primary destructive</Button>
-				<Button variant="primary" type="progressive" disabled="true">Disabled</Button>
+				<div style="margin-bottom:16px;">
+					<Button variant="primary" type="progressive">Primary progressive</Button>
+					<Button variant="primary" type="destructive">Primary destructive</Button>
+					<Button variant="primary" type="progressive" disabled="true">Disabled</Button>
+				</div>
+				<div>
+					<Button variant="primary" type="progressive">
+						<template #prefix>
+							<Icon type="info" size="medium" color="inherit"/>
+						</template>
+						Primary progressive
+					</Button>
+					<Button variant="primary" type="destructive">
+						<template #prefix>
+							<Icon type="trash" size="medium" color="inherit"/>
+						</template>
+						Primary destructive
+					</Button>
+					<Button variant="primary" type="progressive" disabled="true">
+						<template #prefix>
+							<Icon type="edit" size="medium" color="inherit"/>
+						</template>
+						Disabled
+					</Button>
+				</div>
 			</div>
 		`,
 	};
@@ -38,15 +76,43 @@ export function primary(): Component {
 
 export function quiet(): Component {
 	return {
-		components: { Button },
+		components: { Button, Icon },
 		// The quiet button types are all in the same story to achieve high % of visual tests coverage.
 		// Do not use controls to change the type unless you actively decide that is better than having test coverage.
 		template: `
 			<div>
-				<Button variant="quiet" type="neutral">Neutral</Button>
-				<Button variant="quiet" type="progressive">Progressive</Button>
-				<Button variant="quiet" type="destructive">Destructive</Button>
-				<Button variant="quiet" type="neutral" disabled="true">Disabled</Button>
+				<div style="margin-bottom:16px;">
+					<Button variant="quiet" type="neutral">Neutral</Button>
+					<Button variant="quiet" type="progressive">Progressive</Button>
+					<Button variant="quiet" type="destructive">Destructive</Button>
+					<Button variant="quiet" type="neutral" disabled="true">Disabled</Button>
+				</div>
+				<div>
+					<Button variant="quiet" type="neutral">
+						<template #prefix>
+							<Icon type="alert" size="medium" color="inherit"/>
+						</template>
+						Neutral
+					</Button>
+					<Button variant="quiet" type="progressive">
+						<template #prefix>
+							<Icon type="info" size="medium" color="inherit"/>
+						</template>
+						Progressive
+					</Button>
+					<Button variant="quiet" type="destructive">
+						<template #prefix>
+							<Icon type="trash" size="medium" color="inherit"/>
+						</template>
+						Destructive
+					</Button>
+					<Button variant="quiet" type="neutral" disabled="true">
+						<template #prefix>
+							<Icon type="edit" size="medium" color="inherit"/>
+						</template>
+						Disabled
+					</Button>
+				</div>
 			</div>
 		`,
 	};


### PR DESCRIPTION
There are now three slots in Button:
- default one for the label
- prefix one for an icon positioned before the label
- suffix one for an icon positioned after the label

Bug: T270327