### PR TITLE
Fix wikit-Dialog tokens

### DIFF
--- a/tokens/properties/alias.json
+++ b/tokens/properties/alias.json
@@ -500,7 +500,7 @@
                     "value": "{box-shadow.inset.top.thin.value} {color.base.70.value}"
                 },
                 "bottom": {
-                    "value": "{box-shadow.inset.top.thin.value} {color.base.70.value}"
+                    "value": "{box-shadow.inset.bottom.thin.value} {color.base.70.value}"
                 }
             }
         },

--- a/tokens/properties/components/Dialog.json
+++ b/tokens/properties/components/Dialog.json
@@ -3,6 +3,9 @@
         "background-color": {
             "value": "{background.color.base.default.value}"
         },
+        "border-color": {
+            "value": "{border.color.base.subtle.value}"
+        },
         "border-style": {
             "value": "{border.style.base.value}"
         },


### PR DESCRIPTION
A couple of fixes needed to be applied to the Dialog tokens file:

1. The value of `box-shadow-divider-bottom` was corrected, which means that `$wikit-Dialog-header-box-shadow` can now be applied to the Dialog's header (as intended) instead of to the body.

2. The missing token `$wikit-Dialog-border-color` was created: it should replace the alias `$border-color-base-subtle` being used to style the component at the moment.