### PR TITLE
Wrap link to prevent overflow

### DIFF
--- a/vue-components/src/components/Link.vue
+++ b/vue-components/src/components/Link.vue
@@ -88,7 +88,7 @@ export default Vue.extend( {
 
 	&__content {
 		/**
-		* Overflow-wrap value should be overriden to 'anywhere'
+		* Value of overflow-wrap should be overriden to 'anywhere'
 		* to prevent long URLs from overflowing
 		*/
 		overflow-wrap: break-word;

--- a/vue-components/src/components/Link.vue
+++ b/vue-components/src/components/Link.vue
@@ -69,7 +69,6 @@ export default Vue.extend( {
 	display: flex;
 	text-decoration: none;
 	align-items: center;
-	width: max-content;
 
 	&--underlined {
 		text-decoration: underline;
@@ -85,6 +84,15 @@ export default Vue.extend( {
 		&--after {
 			padding-inline-start: $wikit-Link-icon-spacing;
 		}
+	}
+
+	&__content {
+		/**
+		* Overflow-wrap value should be overriden to 'anywhere'
+		* to prevent long URLs from overflowing
+		*/
+		overflow-wrap: break-word;
+		hyphens: auto;
 	}
 }
 </style>

--- a/vue-components/src/components/Link.vue
+++ b/vue-components/src/components/Link.vue
@@ -69,6 +69,8 @@ export default Vue.extend( {
 	display: flex;
 	text-decoration: none;
 	align-items: center;
+	overflow-wrap: break-word;
+	hyphens: auto;
 
 	&--underlined {
 		text-decoration: underline;
@@ -84,15 +86,6 @@ export default Vue.extend( {
 		&--after {
 			padding-inline-start: $wikit-Link-icon-spacing;
 		}
-	}
-
-	&__content {
-		/**
-		* Value of overflow-wrap should be overriden to 'anywhere'
-		* to prevent long URLs from overflowing
-		*/
-		overflow-wrap: break-word;
-		hyphens: auto;
 	}
 }
 </style>


### PR DESCRIPTION
💥 Breaking changes 💥

The current wikit-Link component overflows its container by default. Instead of overriding this behavior in context, we decided to let links wrap.