### PR TITLE
Top-align table headings

### DIFF
--- a/tokens/properties/components/Table.json
+++ b/tokens/properties/components/Table.json
@@ -51,14 +51,17 @@
                     "value": "{transition.duration.medium.value}"
                 }
             },
+            "header": {
+                "font-weight": {
+                    "value": "{font.weight.style.body-bold.value}"
+                },
+                "spacing-vertical": {
+                    "value": "{dimension.spacing.medium.value}"
+                }
+            },
             "hover": {
                 "background-color": {
                     "value": "{background.color.base.default.value}"
-                }
-            },
-            "heading": {
-                "font-weight": {
-                    "value": "{font.weight.style.body-bold.value}"
                 }
             }
         }

--- a/vue-components/src/components/Table.vue
+++ b/vue-components/src/components/Table.vue
@@ -101,7 +101,7 @@ export default Vue.extend( {
 		td[data-header]::before {
 			content: attr(data-header);
 			display: block;
-			font-weight: $wikit-Table-cell-heading-font-weight;
+			font-weight: $wikit-Table-cell-header-font-weight;
 			flex-basis: 40%;
 			// Ensure headers stay exactly 40%
 			// even if values are wider than 60%
@@ -109,7 +109,7 @@ export default Vue.extend( {
 		}
 
 		th:not([data-header]) {
-			font-weight: $wikit-Table-cell-heading-font-weight;
+			font-weight: $wikit-Table-cell-header-font-weight;
 		}
 
 		// Hide empty cells
@@ -160,7 +160,6 @@ export default Vue.extend( {
 			/**
 			* Layout
 			*/
-			height: $wikit-Table-cell-height;
 
 			/**
 			* Borders
@@ -177,23 +176,39 @@ export default Vue.extend( {
 			* Layout
 			*/
 			padding-inline: $wikit-Table-cell-spacing-horizontal;
-			padding-block: $wikit-Table-cell-spacing-vertical;
 
 			/**
 			* Typography
 			*/
 			line-height: $wikit-Table-cell-line-height;
 			text-align: start;
-			vertical-align: middle;
 			overflow-wrap: break-word;
 			hyphens: auto;
 		}
 
-		th {
+		td {
+			/**
+			* Layout
+			*/
+			height: $wikit-Table-cell-height;
+			padding-block: $wikit-Table-cell-spacing-vertical;
+
 			/**
 			* Typography
 			*/
-			font-weight: $wikit-Table-cell-heading-font-weight;
+			vertical-align: middle;
+		}
+
+		th {
+			/**
+			* Layout
+			*/
+			padding-block: $wikit-Table-cell-header-spacing-vertical;
+			/**
+			* Typography
+			*/
+			font-weight: $wikit-Table-cell-header-font-weight;
+			vertical-align: top;
 		}
 
 		&--linear-mobile {


### PR DESCRIPTION
This aligns the wikit-Table's header text at the top in order to improve readability whenever any of the heading wraps into two or more lines.