### PR TITLE
Dialog fixes

### DIFF
--- a/vue-components/src/components/Dialog.vue
+++ b/vue-components/src/components/Dialog.vue
@@ -381,7 +381,7 @@ export default Vue.extend( {
 		position: absolute;
 		inset-block-start: 0;
 		inset-inline-start: 0;
-		transform: translate(-50%, -50%);
+		transform: translate(50%, 50%);
 
 		/**
 		* Colors
@@ -466,7 +466,7 @@ export default Vue.extend( {
 	.fade-zoom-enter-active,
 	.fade-zoom-leave-active {
 		// A default transition duration needs to be added, in order to allow
-		// vue to add the crrect classes
+		// vue to add the correct classes
 		transition-duration: $wikit-Dialog-transition-duration;
 
 		#{$base}__overlay {
@@ -488,7 +488,7 @@ export default Vue.extend( {
 
 		#{$base}__modal {
 			opacity: 0;
-			transform: translate(-50%, -50%) scale(0.7);
+			transform: translate(50%, 50%) scale(0.7);
 		}
 	}
 </style>

--- a/vue-components/src/components/Dialog.vue
+++ b/vue-components/src/components/Dialog.vue
@@ -38,7 +38,7 @@
 						icon-only
 						@click.native="dismiss"
 					>
-						<icon type="close" size="medium" />
+						<icon type="close" size="large" />
 					</Button>
 				</header>
 				<section

--- a/vue-components/stories/Dialog.stories.ts
+++ b/vue-components/stories/Dialog.stories.ts
@@ -37,7 +37,7 @@ export function complex( args: { title: string, actions: string, dismissButton: 
 
 complex.args = {
 	title: 'Complex dialog',
-	dismissButton: 'true',
+	dismissButton: true,
 	actions: [
 		{
 			label: 'Primary action',

--- a/vue-components/stories/Dialog.stories.ts
+++ b/vue-components/stories/Dialog.stories.ts
@@ -23,7 +23,6 @@ export function complex( args: { title: string, actions: string, dismissButton: 
 					:title="title"
 					ref="simple"
 					:actions="actions"
-					style="transform: translate(50%, 50%)"
 					@action="(_, dialog) => dialog.hide()"
 					:dismiss-button="dismissButton"
 					:visible="visible"


### PR DESCRIPTION
This change fixes several issues with the Dialog component, and it's story:

1. The Dialog overlay did not cover the whole viewport/iframe - This was due to some copying and pasting error where the positioning of the dialog within the viewport was reverted from 50%, 50% (x, y) to 0, 0; and a transform was introduced to try and compensate for it. To fix, the transform was removed and the original positioning values restored.

2. The Scrollbars were not restored in storybook, while navigating from the dialog story when the dialog was still open - This was actually two separate issues:
    A. The dialog itself did not complete the hiding animation, and thus the `_restoreScroll` method was not called. This was mitigated by adding a direct call to `_restoreScroll` to the `beforeDestroy` lifecycle hook.
    B. Storybook does not destroy vue components when switching from the canvas tab to the docs tab (see [filed bug on storybook](https://github.com/storybookjs/storybook/issues/12944#issuecomment-882085301)). While this wasn't fixed, this was worked around by ensuring the scrolling is only trapped and restored when the window actually has scrollbars.

3. The Icon for the close button was replaced.

Additionally, minor fixes included in this change are: passing the correct boolean type (instead of string) as the dialog's `dismiss-button` prop, and changing the dialog's viewport height from a fixed height (which caused the docs tab to add extra space to the component), to a max-height.

Bug: [T297093](https://phabricator.wikimedia.org/T297093)