### PR TITLE
Bump version to v2.1.0-alpha.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ development)_
 - New TextArea Component
 - New Table Component
 - New Close, ArrowNext and ArrowPrevious icons
+- New Dialog Component
 
 ### Changed
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-docs",
-	"version": "2.1.0-alpha.7",
+	"version": "2.1.0-alpha.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "2.1.0-alpha.7",
+  "version": "2.1.0-alpha.8",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist -s src/00-doc/static"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^2.1.0-alpha.7",
-    "@wmde/wikit-vue-components": "^2.1.0-alpha.7",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.8",
+    "@wmde/wikit-vue-components": "^2.1.0-alpha.8",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "2.1.0-alpha.7"
+  "version": "2.1.0-alpha.8"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.7",
+  "version": "2.1.0-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.7",
+  "version": "2.1.0-alpha.8",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-vue-components",
-	"version": "2.1.0-alpha.7",
+	"version": "2.1.0-alpha.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "2.1.0-alpha.7",
+  "version": "2.1.0-alpha.8",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -35,7 +35,7 @@
   "types": "dist/main.d.ts",
   "dependencies": {
     "@vue/composition-api": "^1.0.0-beta.20",
-    "@wmde/wikit-tokens": "^2.1.0-alpha.7",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.8",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
This change prepares WiKit for the v2.1.0-alpha.8 pre-release.

Bug: [T295877](https://phabricator.wikimedia.org/T295877)
