### PR TITLE
Export dialog component

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-docs",
-	"version": "2.1.0-alpha.8",
+	"version": "2.1.0-alpha.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "2.1.0-alpha.8",
+  "version": "2.1.0-alpha.9",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist -s src/00-doc/static"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^2.1.0-alpha.8",
-    "@wmde/wikit-vue-components": "^2.1.0-alpha.8",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.9",
+    "@wmde/wikit-vue-components": "^2.1.0-alpha.9",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "2.1.0-alpha.8"
+  "version": "2.1.0-alpha.9"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.8",
+  "version": "2.1.0-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.8",
+  "version": "2.1.0-alpha.9",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-vue-components",
-	"version": "2.1.0-alpha.8",
+	"version": "2.1.0-alpha.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "2.1.0-alpha.8",
+  "version": "2.1.0-alpha.9",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -35,7 +35,7 @@
   "types": "dist/main.d.ts",
   "dependencies": {
     "@vue/composition-api": "^1.0.0-beta.20",
-    "@wmde/wikit-tokens": "^2.1.0-alpha.8",
+    "@wmde/wikit-tokens": "^2.1.0-alpha.9",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",

--- a/vue-components/src/main.ts
+++ b/vue-components/src/main.ts
@@ -1,6 +1,7 @@
 import Button from './components/Button.vue';
 import Checkbox from './components/Checkbox.vue';
 import DateInput from './components/DateInput.vue';
+import Dialog from './components/Dialog.vue';
 import ExtendedNumberInput from './components/ExtendedNumberInput.vue';
 import TextArea from './components/TextArea.vue';
 import Table from './components/Table.vue';
@@ -20,6 +21,7 @@ export {
 	Button,
 	Checkbox,
 	DateInput,
+	Dialog,
 	Dropdown,
 	ExtendedNumberInput,
 	Table,


### PR DESCRIPTION
This change bumps the pre-release version of WiKit, this time also exporting the Dialog component from `main.ts`.