### PR TITLE
Force component imports from main.ts in stories

### DIFF
--- a/vue-components/stories/.eslintrc.js
+++ b/vue-components/stories/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
 	rules: {
 		'max-len': 'off', // lots of long lines due to inline templates
+		'no-restricted-imports': [ // force component imports from src/main.ts to remember exporting
+			'error',
+			{ patterns: [ '@/components/*', '../src/components/*' ] },
+		],
 	},
 };

--- a/vue-components/stories/BouncingDots.stories.ts
+++ b/vue-components/stories/BouncingDots.stories.ts
@@ -1,5 +1,5 @@
-import BouncingDots from '@/components/BouncingDots';
-import { bouncingDotsSizes } from '@/components/bouncingDotsProps';
+import { BouncingDots } from '@/main';
+import { bouncingDotsSizes } from '@/components/bouncingDotsProps'; // eslint-disable-line no-restricted-imports
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Button.stories.ts
+++ b/vue-components/stories/Button.stories.ts
@@ -1,5 +1,4 @@
-import Button from '@/components/Button';
-import Icon from '@/components/Icon';
+import { Button, Icon } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Checkbox.stories.ts
+++ b/vue-components/stories/Checkbox.stories.ts
@@ -1,5 +1,4 @@
-import Checkbox from '@/components/Checkbox';
-import Icon from '@/components/Icon';
+import { Checkbox, Icon } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/DateInput.stories.ts
+++ b/vue-components/stories/DateInput.stories.ts
@@ -1,4 +1,4 @@
-import DateInput from '@/components/DateInput';
+import { DateInput } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Dialog.stories.ts
+++ b/vue-components/stories/Dialog.stories.ts
@@ -1,5 +1,4 @@
-import Dialog from '@/components/Dialog';
-import Button from '@/components/Button';
+import { Button, Dialog } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Dropdown.stories.ts
+++ b/vue-components/stories/Dropdown.stories.ts
@@ -1,7 +1,6 @@
-import Dropdown from '@/components/Dropdown';
-import Icon from '@/components/Icon';
+import { Dropdown, Icon } from '@/main';
 import { Component } from 'vue';
-import { MenuItem } from '@/components/MenuItem';
+import { MenuItem } from '@/components/MenuItem'; // eslint-disable-line no-restricted-imports
 
 export default {
 	component: Dropdown,

--- a/vue-components/stories/ExtendedNumberInput.stories.ts
+++ b/vue-components/stories/ExtendedNumberInput.stories.ts
@@ -1,4 +1,4 @@
-import ExtendedNumberInput from '@/components/ExtendedNumberInput';
+import { ExtendedNumberInput } from '@/main';
 import { Component } from 'vue';
 import { ErrorProp } from '../dist/compositions/validatable';
 

--- a/vue-components/stories/Icon.stories.ts
+++ b/vue-components/stories/Icon.stories.ts
@@ -1,5 +1,9 @@
-import Icon from '@/components/Icon';
-import { iconSizes, IconDirection, IconTypes } from '@/components/iconProps';
+import { Icon } from '@/main';
+import { // eslint-disable-line no-restricted-imports
+	iconSizes,
+	IconDirection,
+	IconTypes,
+} from '@/components/iconProps';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Input.stories.ts
+++ b/vue-components/stories/Input.stories.ts
@@ -1,4 +1,4 @@
-import Input from '@/components/Input';
+import { Input } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/InputWithExtender.stories.ts
+++ b/vue-components/stories/InputWithExtender.stories.ts
@@ -1,4 +1,4 @@
-import InputWithExtender from '../src/components/InputWithExtender.vue';
+import { InputWithExtender } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Link.stories.ts
+++ b/vue-components/stories/Link.stories.ts
@@ -1,4 +1,4 @@
-import Link from '@/components/Link';
+import { Link } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/Lookup.stories.ts
+++ b/vue-components/stories/Lookup.stories.ts
@@ -1,7 +1,6 @@
-import Lookup from '@/components/Lookup';
-import Icon from '@/components/Icon';
+import { Lookup, Icon } from '@/main';
 import { Component } from 'vue';
-import { MenuItem } from '@/components/MenuItem';
+import { MenuItem } from '@/components/MenuItem'; // eslint-disable-line no-restricted-imports
 
 export default {
 	component: Lookup,

--- a/vue-components/stories/Message.stories.ts
+++ b/vue-components/stories/Message.stories.ts
@@ -1,4 +1,4 @@
-import Message from '@/components/Message';
+import { Message } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/OptionsMenu.stories.ts
+++ b/vue-components/stories/OptionsMenu.stories.ts
@@ -1,6 +1,6 @@
-import OptionsMenu from '@/components/OptionsMenu';
+import { OptionsMenu } from '@/main';
 import { Component } from 'vue';
-import { MenuItem } from '@/components/MenuItem';
+import { MenuItem } from '@/components/MenuItem'; // eslint-disable-line no-restricted-imports
 
 export default {
 	component: OptionsMenu,

--- a/vue-components/stories/Popover.stories.ts
+++ b/vue-components/stories/Popover.stories.ts
@@ -1,7 +1,5 @@
-import Popover from '@/components/Popover';
-import Icon from '@/components/Icon';
-import Button from '@/components/Button';
-import { PopoverPositions } from '@/components/PopoverProps';
+import { Popover, Icon, Button } from '@/main';
+import { PopoverPositions } from '@/components/PopoverProps'; // eslint-disable-line no-restricted-imports
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/QuantityInput.stories.ts
+++ b/vue-components/stories/QuantityInput.stories.ts
@@ -1,7 +1,7 @@
-import QuantityInput from '@/components/QuantityInput';
+import { QuantityInput } from '@/main';
 import { Component } from 'vue';
-import { MenuItem } from '../src/components/MenuItem';
-import validateExtendedNumberInput from '@/components/util/validateExtendedNumberInput';
+import { MenuItem } from '@/components/MenuItem'; // eslint-disable-line no-restricted-imports
+import validateExtendedNumberInput from '@/components/util/validateExtendedNumberInput'; // eslint-disable-line no-restricted-imports
 
 const vegetableItems = [
 	{

--- a/vue-components/stories/Table.stories.ts
+++ b/vue-components/stories/Table.stories.ts
@@ -1,4 +1,4 @@
-import Table from '@/components/Table';
+import { Table } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/TextArea.stories.ts
+++ b/vue-components/stories/TextArea.stories.ts
@@ -1,4 +1,4 @@
-import TextArea from '@/components/TextArea';
+import { TextArea } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/TextInput.stories.ts
+++ b/vue-components/stories/TextInput.stories.ts
@@ -1,5 +1,4 @@
-import TextInput from '@/components/TextInput';
-import Icon from '@/components/Icon';
+import { TextInput, Icon } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/ToggleButton.stories.ts
+++ b/vue-components/stories/ToggleButton.stories.ts
@@ -1,5 +1,4 @@
-import ToggleButton from '@/components/ToggleButton';
-import ToggleButtonGroup from '@/components/ToggleButtonGroup';
+import { ToggleButton, ToggleButtonGroup } from '@/main';
 import { Component } from 'vue';
 
 export default {

--- a/vue-components/stories/ValidationMessage.stories.ts
+++ b/vue-components/stories/ValidationMessage.stories.ts
@@ -1,4 +1,4 @@
-import ValidationMessage from '@/components/ValidationMessage';
+import { ValidationMessage } from '@/main';
 import { Component } from 'vue';
 
 export default {


### PR DESCRIPTION
By forcing components to be imported from `main.ts` instead of directly importing it from the source file, we make it harder for ourselves to forget exporting a component from the vue-components package (e.g. 2c6f608ce7bccbcf7ca06ff6a770cf3c5ba715a4).

I initially thought that the number of `// eslint-disable-line no-restricted-imports` I had to add is something that should be worked around as part of this PR, however, I believe this actually shows a problem worth pointing out: whatever is useful for the component stories is likely also useful for consuming applications. Instead of making it more convenient to ignore those, we should probably think about ways to export these types/enums/constants as well!