### PR TITLE
Prevent dropdown from emitting an 'input' event if the selected option is selected again

### DIFF
--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -158,8 +158,8 @@ export default defineComponent( {
 
 			// the following comment generates the event's description for the docs tab in storybook
 			/**
-			 * This event is emitted whenever an item is selected on the Dropdown.
-			 * As long as the selected item is different from the current selection.
+			 * This event is emitted whenever an item is selected on the Dropdown,
+			 * as long as the selected item is different from the current selection.
 			 *
 			 * @property {MenuItem|null} The event payload contains the whole MenuItem object.
 			 *                           The payload is null when no item is selected or the item is deselected.

--- a/vue-components/src/components/Dropdown.vue
+++ b/vue-components/src/components/Dropdown.vue
@@ -159,11 +159,14 @@ export default defineComponent( {
 			// the following comment generates the event's description for the docs tab in storybook
 			/**
 			 * This event is emitted whenever an item is selected on the Dropdown.
+			 * As long as the selected item is different from the current selection.
 			 *
 			 * @property {MenuItem|null} The event payload contains the whole MenuItem object.
 			 *                           The payload is null when no item is selected or the item is deselected.
 			 */
-			this.$emit( 'input', menuItem );
+			if ( menuItem !== this.value ) {
+				this.$emit( 'input', menuItem );
+			}
 		},
 		onClick(): void {
 			this.startShowingTheMenu();

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -5,9 +5,11 @@ import OptionsMenu from '@/components/OptionsMenu.vue';
 import ValidationMessage from '@/components/ValidationMessage.vue';
 import { MenuItem } from '@/components/MenuItem';
 
-async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[] ): Promise<Wrapper<Dropdown>> {
+async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[],
+	value?: Record<string, any> | null ): Promise<Wrapper<Dropdown>> {
 	const wrapper = mount( Dropdown, { propsData: {
 		menuItems,
+		value: value || null,
 	} } );
 	wrapper.find( '.wikit-Dropdown__select' ).trigger( 'click' );
 
@@ -121,6 +123,21 @@ describe( 'Dropdown', () => {
 		wrapper.findAll( '.wikit-OptionsMenu__item' ).at( selectedItem ).element.click();
 
 		expect( wrapper.emitted( 'input' )![ 0 ] ).toEqual( [ menuItems[ selectedItem ] ] );
+	} );
+
+	it( 'doesn\'t emit an `input` event if currently selected item is selected again', async () => {
+		const menuItems = [
+			{ label: 'potato', description: 'root vegetable' },
+			{ label: 'duck', description: 'aquatic bird' },
+		];
+		const selectedItem = 1;
+		const value = menuItems[ selectedItem ];
+		const wrapper = await createDropdownWrapperWithExpandedMenu( menuItems, value );
+
+		wrapper.findAll( '.wikit-OptionsMenu__item' ).at( selectedItem ).element.click();
+
+		expect( wrapper.emitted( 'input' ) ).toBe( undefined );
+
 	} );
 
 	it( 'shows the currently selected menu item after reopening it', async () => {

--- a/vue-components/tests/unit/components/Dropdown.spec.ts
+++ b/vue-components/tests/unit/components/Dropdown.spec.ts
@@ -6,10 +6,10 @@ import ValidationMessage from '@/components/ValidationMessage.vue';
 import { MenuItem } from '@/components/MenuItem';
 
 async function createDropdownWrapperWithExpandedMenu( menuItems: MenuItem[],
-	value?: Record<string, any> | null ): Promise<Wrapper<Dropdown>> {
+	value?: MenuItem ): Promise<Wrapper<Dropdown>> {
 	const wrapper = mount( Dropdown, { propsData: {
 		menuItems,
-		value: value || null,
+		value,
 	} } );
 	wrapper.find( '.wikit-Dropdown__select' ).trigger( 'click' );
 


### PR DESCRIPTION
This prevents the wikit-Dropdown component from emitting an 'input' event in case users click the selected option from the menu again.

Issue: [T298020](https://phabricator.wikimedia.org/T298020)