### PR TITLE
revert arrow function to traditional js to support IE11

### DIFF
--- a/vue-components/stories/Dialog.stories.ts
+++ b/vue-components/stories/Dialog.stories.ts
@@ -23,7 +23,7 @@ export function complex( args: { title: string; actions: string; dismissButton: 
 					:title="title"
 					ref="simple"
 					:actions="actions"
-					@action="function ( _, dialog ){ return dialog.hide() }"
+					@action="function ( _, dialog ){ dialog.hide() }"
 					:dismiss-button="dismissButton"
 					:visible="visible"
 				>

--- a/vue-components/stories/Dialog.stories.ts
+++ b/vue-components/stories/Dialog.stories.ts
@@ -23,7 +23,7 @@ export function complex( args: { title: string; actions: string; dismissButton: 
 					:title="title"
 					ref="simple"
 					:actions="actions"
-					@action="(_, dialog) => dialog.hide()"
+					@action="function ( _, dialog ){ return dialog.hide() }"
 					:dismiss-button="dismissButton"
 					:visible="visible"
 				>


### PR DESCRIPTION
Phab Task: https://phabricator.wikimedia.org/T298238

IE11 does not support es6 syntax. function adjusted to traditional js seems 