### PR TITLE
Enable testing the Dialog component on IE11

### DIFF
--- a/vue-components/tests/e2e/specs/Dialog.test.js
+++ b/vue-components/tests/e2e/specs/Dialog.test.js
@@ -26,11 +26,6 @@ describe( 'Dialog', function () {
 	} );
 
 	it( 'traps page focus, so that only visually focused elements are tab-able', function ( client ) {
-		const currentBrowser = client.options.desiredCapabilities.browserName;
-
-		if ( currentBrowser === 'internet explorer' ) {
-			return; // https://phabricator.wikimedia.org/T298238
-		}
 		client
 			.click( '.wikit-Button' )
 			.pause( 500 )
@@ -60,10 +55,6 @@ describe( 'Dialog', function () {
 	} );
 
 	it( 'prevents underlying page from scrolling when opened and on initial render', function ( client ) {
-		if ( client.options.desiredCapabilities.browserName === 'internet explorer' ) {
-			return; // https://phabricator.wikimedia.org/T298238
-		}
-
 		client
 			.execute( 'document.body.style.height = "150vh";' )
 			.execute( 'window.scrollTo( 0, document.body.scrollHeight );' )
@@ -80,10 +71,6 @@ describe( 'Dialog', function () {
 	} );
 
 	it( 'resets dialog scroll bars to top when closed and reopened', function ( client ) {
-		if ( client.options.desiredCapabilities.browserName === 'internet explorer' ) {
-			return; // https://phabricator.wikimedia.org/T298238
-		}
-
 		client
 			.click( '.wikit-Button' )
 			.pause( 500 )


### PR DESCRIPTION
Removed code that excluded tests on IE11. 
Phab task: https://phabricator.wikimedia.org/T298256