### PR TITLE
Add additional build for Vue 3 compatibility mode

### DIFF
--- a/vue-components/README.md
+++ b/vue-components/README.md
@@ -4,6 +4,8 @@ The component implementation of [WiKit](https://github.com/wmde/wikit) in vue
 
 ## Installation
 
+## Vue 2
+
 **The library assumes the consuming application uses Vue.js v2.6+.**
 
 #### 1. Install via npm
@@ -24,6 +26,16 @@ or in your entry component, e.g `App.vue`, add
 
 `import { Button } from '@wmde/wikit-vue-components';`
 
+### Vue 3 migration build
+
+There is an experimental build that works with the Vue 3 migration build (`@vue3/compat`).
+To use it, change your imports to
+`@wmde/wikit-vue-components/dist/wikit-vue-components-vue3compat.common.js`
+(or configure `@wmde/wikit-vue-components` to be an alias for that),
+then configure your build so that `vue` and `@vue/composition-api` are both aliases for `@vue/compat`.
+
+Keep in mind that this build still uses Vue 2 APIs,
+so it is only compatible with the migration build, not with pure Vue 3.
 
 ## Development
 

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json && tsc --emitDeclarationOnly",
+    "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json && tsc --emitDeclarationOnly && VUE_APP_VUE3COMPAT=true vue-cli-service build --target lib --formats commonjs --name wikit-vue-components-vue3compat --no-clean src/main.ts",
     "test:unit": "vue-cli-service test:unit",
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
     "e2e": "vue-cli-service test:e2e",

--- a/vue-components/src/components/Button.vue
+++ b/vue-components/src/components/Button.vue
@@ -47,7 +47,8 @@ Vue.use( VueCompositionAPI );
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1581369#c5
  */
 export default defineComponent( {
-	name: 'Button',
+	// eslint-disable-next-line no-undef
+	name: process.env.VUE_APP_VUE3COMPAT ? 'WikitButton' : 'Button',
 	props: {
 		/**
 		 * The type of the button

--- a/vue-components/src/components/Input.vue
+++ b/vue-components/src/components/Input.vue
@@ -17,7 +17,8 @@ import Vue from 'vue';
  * identical.
  */
 export default Vue.extend( {
-	name: 'Input',
+	// eslint-disable-next-line no-undef
+	name: process.env.VUE_APP_VUE3COMPAT ? 'WikitInput' : 'Input',
 	props: {
 		feedbackType: {
 			type: String,

--- a/vue-components/src/components/Table.vue
+++ b/vue-components/src/components/Table.vue
@@ -33,7 +33,8 @@ import { Breakpoint, validateBreakpoint } from './Breakpoint';
  * ```
  */
 export default Vue.extend( {
-	name: 'Table',
+	// eslint-disable-next-line no-undef
+	name: process.env.VUE_APP_VUE3COMPAT ? 'WikitTable' : 'Table',
 	props: {
 		/**
 		 * Sets the viewport breakpoint that triggers the linearized view of the

--- a/vue-components/vue.config.js
+++ b/vue-components/vue.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+	configureWebpack: () => ( {
+		externals: process.env.VUE_APP_VUE3COMPAT ? [ 'vue', '@vue/composition-api' ] : [ 'vue' ],
+	} ),
 	css: {
 		loaderOptions: {
 			sass: {


### PR DESCRIPTION
This adds an extra build to dist, named `wikit-vue-components-vue3compat`, which includes some changes to make Wikit compatible with the Vue 3 migration build:

- the `@vue/composition-api` dependency is externalized, because it’s incompatible with Vue 3
- components that use an HTML element with the same name (e.g. `Button`/`<button>`) internally use a non-conflicting name (but are still imported and used under their original name elsewhere), because otherwise there are sometimes infinite loops when mounting them

The intention is that this additional build can be used in two ways:

1. with Vue 2, where `vue` is `vue@^2` and `@vue/composition-api` is `@vue/composition-api@^1`
2. with Vue 3, where `vue` is `@vue/compat@^3` and `@vue/composition-api` is an alias for the same module

Note that even in option 1, `@vue/composition-api` must now be available in the environment, whereas in the regular (non-vue3compat) build it is built into the bundle and only Vue itself is required.

Note that this only makes Wikit compatible with the migration build, not with pure Vue 3: we still use Vue 2 APIs, this just includes the bare minimum of changes to make the library work under the migration build.