### PR TITLE
Split build command into several

### DIFF
--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -10,7 +10,10 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json && tsc --emitDeclarationOnly && VUE_APP_VUE3COMPAT=true vue-cli-service build --target lib --formats commonjs --name wikit-vue-components-vue3compat --no-clean src/main.ts",
+    "build": "npm-run-all -s build:main build:tsdecl build:vue3compat",
+    "build:main": "vue-cli-service build --target lib --formats commonjs --name wikit-vue-components src/main.ts --report --report-json",
+    "build:tsdecl": "tsc --emitDeclarationOnly",
+    "build:vue3compat": "VUE_APP_VUE3COMPAT=true vue-cli-service build --target lib --formats commonjs --name wikit-vue-components-vue3compat --no-clean src/main.ts",
     "test:unit": "vue-cli-service test:unit",
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
     "e2e": "vue-cli-service test:e2e",


### PR DESCRIPTION
Explicitly listing the three relevant subcommands, because we don’t want build:extract-stories and build:storybook to become part of build.