### PR TITLE
Stop building and testing for IE11

### DIFF
--- a/vue-components/.browserslistrc
+++ b/vue-components/.browserslistrc
@@ -2,8 +2,7 @@ last 2 Chrome versions
 last 2 Firefox versions
 last 2 Opera versions
 last 2 Edge versions
-IE >=11
-Safari >=5.1
-iOS >=6.1
-Android >=4.1
-defaults
+
+Safari >=10
+iOS >=10
+last 2 Android versions

--- a/vue-components/nightwatch.config.js
+++ b/vue-components/nightwatch.config.js
@@ -62,15 +62,6 @@ module.exports = {
 			},
 		},
 
-		sauceIE: {
-			extends: 'sauceLabs',
-			desiredCapabilities: {
-				browserName: 'internet explorer',
-				platform: 'Windows 10',
-				version: 'latest',
-			},
-		},
-
 		sauceEdge: {
 			extends: 'sauceLabs',
 			desiredCapabilities: {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -14,7 +14,7 @@
     "test:unit": "vue-cli-service test:unit",
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
     "e2e": "vue-cli-service test:e2e",
-    "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceIE,sauceEdge,sauceSafari",
+    "e2e:saucelabs": "env DATE=\"$(date)\" nightwatch --config nightwatch.config.js --env sauceChrome,sauceFirefox,sauceEdge,sauceSafari",
     "build:extract-stories": "npx sb extract storybook-static storybook-static/stories.json",
     "build:storybook": "build-storybook",
     "fix": "eslint --ext .js,.ts,.vue --fix .",


### PR DESCRIPTION
This branch is going to target Vue 3 which no longer support IE11 and
Safari older than 10. See also wikimedia/browserslist-config-wikimedia#6

This should make future builds more robust and slightly faster.

Bug: T301155