### PR TITLE
Replace stylelint-use-logical with stylelint-use-logical-spec

### DIFF
--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -65,7 +65,7 @@
 				"stylelint": "^13.13.1",
 				"stylelint-config-sass-guidelines": "^7.1.0",
 				"stylelint-config-standard": "^20.0.0",
-				"stylelint-use-logical": "^1.1.0",
+				"stylelint-use-logical-spec": "^3.2.2",
 				"typescript": "~4.5.0",
 				"vue-template-compiler": "^2.6.12"
 			}
@@ -32532,15 +32532,16 @@
 				"stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
 			}
 		},
-		"node_modules/stylelint-use-logical": {
-			"version": "1.1.0",
+		"node_modules/stylelint-use-logical-spec": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
+			"integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
 			"dev": true,
-			"license": "CC0-1.0",
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^9.6.0"
+				"stylelint": ">=13"
 			}
 		},
 		"node_modules/stylelint/node_modules/@nodelib/fs.stat": {
@@ -60459,8 +60460,10 @@
 				"postcss-value-parser": "^4.1.0"
 			}
 		},
-		"stylelint-use-logical": {
-			"version": "1.1.0",
+		"stylelint-use-logical-spec": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
+			"integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
 			"dev": true,
 			"requires": {}
 		},

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -91,7 +91,7 @@
     "stylelint": "^13.13.1",
     "stylelint-config-sass-guidelines": "^7.1.0",
     "stylelint-config-standard": "^20.0.0",
-    "stylelint-use-logical": "^1.1.0",
+    "stylelint-use-logical-spec": "^3.2.2",
     "typescript": "~4.5.0",
     "vue-template-compiler": "^2.6.12"
   },

--- a/vue-components/stylelint.config.js
+++ b/vue-components/stylelint.config.js
@@ -3,11 +3,13 @@ module.exports = {
 		'stylelint-config-sass-guidelines',
 	],
 	plugins: [
-		'stylelint-use-logical',
+		'stylelint-use-logical-spec',
 	],
 	rules: {
 		'indentation': 'tab',
-		'csstools/use-logical': 'always',
+		'liberty/use-logical-spec': [ 'always', {
+			except: [ /\b(width|height)$/ ],
+		} ],
 		/* eslint-disable */
 		// CSS Logical Properties do not support the shorthand 'margin' and 'padding' yet
 		// https://wmde.github.io/wikit/?path=/story/documentation-decisions-and-adrs-adrs-9-rtl-support--page#consequences


### PR DESCRIPTION
The original stylelint-use-logical seems to be effectively unmaintained, and is causing problems with its old stylelint peer dependency; its fork stylelint-use-logical-spec seems reasonably active, has a comparable number of downloads, and is compatible with newer stylelint.

The new version also complains about width/height (wanting them replaced with inline/block-size), but at least one of these replacements is not trivial (in OptionsMenu, the max-width involves the vw unit), so disable this for now.


---

Inspired by 55169482695961c64aa5ceef2a1b7252a398c291 from #543.