### PR TITLE
Upgrade eslint config and suppress reported false-positive errors

### DIFF
--- a/vue-components/.eslintrc.js
+++ b/vue-components/.eslintrc.js
@@ -1,3 +1,5 @@
+require( '@rushstack/eslint-patch/modern-module-resolution' );
+
 module.exports = {
 	extends: [
 		'wikimedia',

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -17,6 +17,7 @@
 				"vue": "^2.6.12"
 			},
 			"devDependencies": {
+				"@rushstack/eslint-patch": "^1.1.0",
 				"@storybook/addon-a11y": "~6.4.18",
 				"@storybook/addon-backgrounds": "~6.4.18",
 				"@storybook/addon-controls": "~6.4.18",
@@ -37,11 +38,11 @@
 				"@vue/cli-service": "^4.5.15",
 				"@vue/eslint-config-typescript": "^8.0.0",
 				"@vue/test-utils": "^1.3.0",
-				"@wmde/eslint-config-wikimedia-typescript": "^0.2.0",
+				"@wmde/eslint-config-wikimedia-typescript": "^0.2.2",
 				"chromatic": "^6.4.3",
 				"chromedriver": "83",
 				"eslint": "^7.13.0",
-				"eslint-config-wikimedia": "^0.16.2",
+				"eslint-config-wikimedia": "^0.21.0",
 				"eslint-plugin-filenames": "^1.3.2",
 				"eslint-plugin-import": "^2.25.4",
 				"eslint-plugin-jsdoc": "^37.8.2",
@@ -2905,6 +2906,26 @@
 				"@hapi/hoek": "^8.3.0"
 			}
 		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
 		"node_modules/@intervolga/optimize-cssnano-plugin": {
 			"version": "1.0.6",
 			"dev": true,
@@ -4935,6 +4956,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@mdn/browser-compat-data": {
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+			"dev": true
+		},
 		"node_modules/@mdx-js/loader": {
 			"version": "1.6.22",
 			"dev": true,
@@ -5142,6 +5169,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
 			}
+		},
+		"node_modules/@rushstack/eslint-patch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz",
+			"integrity": "sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==",
+			"dev": true
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "0.7.0",
@@ -9871,13 +9904,14 @@
 			}
 		},
 		"node_modules/@wmde/eslint-config-wikimedia-typescript": {
-			"version": "0.2.0",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@wmde/eslint-config-wikimedia-typescript/-/eslint-config-wikimedia-typescript-0.2.2.tgz",
+			"integrity": "sha512-lgzW2LoqEItTD9rAV1jbj7QbRRvMwty1EHvSemSv8/y9MSJXbUk7hMgiGBfzAhS3Re/1zFVlM090Ep7gxcDoew==",
 			"dev": true,
-			"license": "GPL-2.0+",
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^3.1.0",
-				"@typescript-eslint/parser": "^3.1.0",
-				"eslint-config-wikimedia": "^0.15.3"
+				"@typescript-eslint/eslint-plugin": "^5.6.0",
+				"@typescript-eslint/parser": "^5.6.0",
+				"eslint-config-wikimedia": "^0.21.0"
 			}
 		},
 		"node_modules/@xtuc/ieee754": {
@@ -10547,6 +10581,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ast-metadata-inferer": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+			"integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+			"dev": true,
+			"dependencies": {
+				"@mdn/browser-compat-data": "^3.3.14"
 			}
 		},
 		"node_modules/ast-types": {
@@ -13207,6 +13250,18 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/clean-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/clean-stack": {
@@ -16368,95 +16423,823 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia": {
-			"version": "0.16.2",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.21.0.tgz",
+			"integrity": "sha512-+KoUKaWSKTgIx+Run9gdbGXi6Uox2/JxgROTVmA6yi4mnMuFWwpBXzYFjqZPUT7dzmJSTO3uxwsR44F8GnZhpg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"eslint": "^7.2.0",
-				"eslint-plugin-es": "^3.0.1",
-				"eslint-plugin-jsdoc": "^27.1.2",
-				"eslint-plugin-json": "^2.1.1",
-				"eslint-plugin-mediawiki": "^0.2.5",
-				"eslint-plugin-mocha": "^7.0.1",
-				"eslint-plugin-no-jquery": "^2.4.1",
+				"eslint": "^7.32.0",
+				"eslint-plugin-compat": "^3.13.0",
+				"eslint-plugin-es": "^4.1.0",
+				"eslint-plugin-jsdoc": "^37.0.3",
+				"eslint-plugin-json-es": "^1.5.4",
+				"eslint-plugin-mediawiki": "^0.3.0",
+				"eslint-plugin-mocha": "^9.0.0",
+				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-qunit": "^4.2.0",
-				"eslint-plugin-vue": "^6.2.2",
-				"eslint-plugin-wdio": "^6.0.12"
+				"eslint-plugin-qunit": "^7.0.0",
+				"eslint-plugin-unicorn": "^37.0.1",
+				"eslint-plugin-vue": "^8.0.2",
+				"eslint-plugin-wdio": "^7.4.2"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/comment-parser": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-			"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+		"node_modules/eslint-config-wikimedia/node_modules/@babel/code-frame": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/@eslint/eslintrc": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+			"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^13.9.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">=8"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-jsdoc": {
-			"version": "27.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-27.1.2.tgz",
-			"integrity": "sha512-iWrG2ZK4xrxamoMkoyzgkukdmfqWc5Ncd6K+CnwRgxrbwjQQpzmt5Kl8GB0l12R0oUK2AF+9tGFJKNGzuyz79Q==",
+		"node_modules/eslint-config-wikimedia/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"dependencies": {
-				"comment-parser": "^0.7.5",
-				"debug": "^4.1.1",
-				"jsdoctypeparser": "^6.1.0",
-				"lodash": "^4.17.15",
-				"regextras": "^0.7.1",
-				"semver": "^6.3.0",
-				"spdx-expression-parse": "^3.0.1"
+				"color-convert": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=8"
 			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0"
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-			"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+		"node_modules/eslint-config-wikimedia/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"dependencies": {
-				"natural-compare": "^1.4.0",
-				"semver": "^5.6.0",
-				"vue-eslint-parser": "^7.0.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8.10"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/ci-info": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+			"dev": true
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "7.12.11",
+				"@eslint/eslintrc": "^0.4.3",
+				"@humanwhocodes/config-array": "^0.5.0",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"enquirer": "^2.3.5",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^2.0.0",
+				"espree": "^7.3.1",
+				"esquery": "^1.4.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.1.2",
+				"globals": "^13.6.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.0.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"progress": "^2.0.0",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
+				"table": "^6.0.9",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-es": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+			"dev": true,
+			"dependencies": {
+				"eslint-utils": "^2.0.0",
+				"regexpp": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
 			},
 			"peerDependencies": {
-				"eslint": "^5.0.0 || ^6.0.0"
+				"eslint": ">=4.19.1"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-unicorn": {
+			"version": "37.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
+			"integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
 			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/eslint-config-wikimedia/node_modules/regextras": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-			"integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
-			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.14.9",
+				"ci-info": "^3.2.0",
+				"clean-regexp": "^1.0.0",
+				"eslint-template-visitor": "^2.3.2",
+				"eslint-utils": "^3.0.0",
+				"esquery": "^1.4.0",
+				"indent-string": "4",
+				"is-builtin-module": "^3.1.0",
+				"lodash": "^4.17.21",
+				"pluralize": "^8.0.0",
+				"read-pkg-up": "^7.0.1",
+				"regexp-tree": "^0.1.23",
+				"safe-regex": "^2.1.1",
+				"semver": "^7.3.5",
+				"strip-indent": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=0.1.14"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.32.0"
 			}
 		},
-		"node_modules/eslint-config-wikimedia/node_modules/semver": {
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+			"integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.12.16",
+				"@babel/eslint-parser": "^7.12.16",
+				"eslint-visitor-keys": "^2.0.0",
+				"esquery": "^1.3.1",
+				"multimap": "^1.1.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor/node_modules/@babel/eslint-parser": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+			"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.11.0",
+				"eslint": "^7.5.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor/node_modules/semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-unicorn/node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.5.0.tgz",
+			"integrity": "sha512-i1uHCTAKOoEj12RDvdtONWrGzjFm/djkzqfhmQ0d6M/W8KM81mhswd/z+iTZ0jCpdUedW3YRgcVfQ37/J4zoYQ==",
+			"dev": true,
+			"dependencies": {
+				"eslint-utils": "^3.0.0",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.3.5",
+				"vue-eslint-parser": "^8.0.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/acorn": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/eslint-scope": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/espree": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+			"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.7.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz",
+			"integrity": "sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.2",
+				"eslint-scope": "^7.0.0",
+				"eslint-visitor-keys": "^3.1.0",
+				"espree": "^9.0.0",
+				"esquery": "^1.4.0",
+				"lodash": "^4.17.21",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/espree": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+			"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^7.4.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^1.3.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"dependencies": {
+				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/flat-cache": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"dev": true,
+			"dependencies": {
+				"flatted": "^3.1.0",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/flatted": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+			"dev": true
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/globals": {
+			"version": "13.12.1",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+			"integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/globals/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/optionator": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/read-pkg-up": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/safe-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+			"dev": true,
+			"dependencies": {
+				"regexp-tree": "~0.1.1"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/table": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+			"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/table/node_modules/ajv": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+			"integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint-config-wikimedia/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
@@ -16607,6 +17390,89 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/eslint-plugin-compat": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.13.0.tgz",
+			"integrity": "sha512-cv8IYMuTXm7PIjMVDN2y4k/KVnKZmoNGHNq27/9dLstOLydKblieIv+oe2BN2WthuXnFNhaNvv3N1Bvl4dbIGA==",
+			"dev": true,
+			"dependencies": {
+				"@mdn/browser-compat-data": "^3.3.14",
+				"ast-metadata-inferer": "^0.7.0",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"core-js": "^3.16.2",
+				"find-up": "^5.0.0",
+				"lodash.memoize": "4.1.2",
+				"semver": "7.3.5"
+			},
+			"engines": {
+				"node": ">=9.x"
+			},
+			"peerDependencies": {
+				"eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-compat/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-compat/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-compat/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-compat/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint-plugin-es": {
 			"version": "3.0.1",
 			"dev": true,
@@ -16737,80 +17603,131 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint-plugin-json": {
-			"version": "2.1.2",
+		"node_modules/eslint-plugin-json-es": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.4.tgz",
+			"integrity": "sha512-DdjnNMUZ1iMrUXfxUQrTU7IyoEOsa4Kg0Zd6nOyOq1mUb75deK7NrcbI1FlWGdGVgqX99bUOD27i81EYiG794Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.19",
-				"vscode-json-languageservice": "^3.7.0"
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">= 7"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/acorn": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/espree": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+			"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.7.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
-			"version": "0.2.6",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.3.0.tgz",
+			"integrity": "sha512-Lhyj2PSkhDzYSc1PNbURysY/WoqvY0brw558ZInT3erzf5KUlro18MTKFdV+nlht475ZgnsfHsgfg6Ut2w1SVg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"eslint-plugin-vue": "^6.2.2",
-				"upath": "^1.2.0"
+				"eslint-plugin-vue": "^7.20.0",
+				"upath": "^2.0.1"
 			},
 			"peerDependencies": {
 				"eslint": ">=5.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/eslint-plugin-vue": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-			"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+		"node_modules/eslint-plugin-mediawiki/node_modules/upath": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
 			"dev": true,
-			"dependencies": {
-				"natural-compare": "^1.4.0",
-				"semver": "^5.6.0",
-				"vue-eslint-parser": "^7.0.0"
-			},
 			"engines": {
-				"node": ">=8.10"
-			},
-			"peerDependencies": {
-				"eslint": "^5.0.0 || ^6.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-mediawiki/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
+				"node": ">=4",
+				"yarn": "*"
 			}
 		},
 		"node_modules/eslint-plugin-mocha": {
-			"version": "7.0.1",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
+			"integrity": "sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"eslint-utils": "^2.0.0",
-				"ramda": "^0.27.0"
+				"eslint-utils": "^3.0.0",
+				"ramda": "^0.27.1"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-mocha/node_modules/ramda": {
-			"version": "0.27.1",
+		"node_modules/eslint-plugin-mocha/node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
-			"license": "MIT"
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-plugin-mocha/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-mocha/node_modules/ramda": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+			"integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+			"dev": true
 		},
 		"node_modules/eslint-plugin-no-jquery": {
-			"version": "2.5.0",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
+			"integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
 			"dev": true,
-			"license": "MIT",
 			"peerDependencies": {
 				"eslint": ">=2.3.0"
 			}
@@ -16863,11 +17780,43 @@
 			}
 		},
 		"node_modules/eslint-plugin-qunit": {
-			"version": "4.3.0",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+			"integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
 			"dev": true,
-			"license": "MIT",
+			"dependencies": {
+				"eslint-utils": "^3.0.0",
+				"requireindex": "^1.2.0"
+			},
 			"engines": {
-				"node": "6.x || 8.x || >=10.0.0"
+				"node": "12.x || 14.x || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-qunit/node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-plugin-qunit/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-standard": {
@@ -16937,11 +17886,12 @@
 			}
 		},
 		"node_modules/eslint-plugin-wdio": {
-			"version": "6.6.0",
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-wdio/-/eslint-plugin-wdio-7.4.2.tgz",
+			"integrity": "sha512-tkISFycJmRFMKsEjetRcAmWSHKJKnw5rKHDxfE7Ob3tF5lbmYlCLfNKH0UwanOpSdulpe52s3K+CBHSd6qUUNQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -21005,6 +21955,30 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-builtin-module": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"dev": true,
+			"dependencies": {
+				"builtin-modules": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/is-builtin-module/node_modules/builtin-modules": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -24742,18 +25716,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/jsdoctypeparser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
-			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
-			"dev": true,
-			"bin": {
-				"jsdoctypeparser": "bin/jsdoctypeparser"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/jsdom": {
 			"version": "11.12.0",
 			"dev": true,
@@ -24866,11 +25828,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "2.4.0",
@@ -26277,6 +27234,12 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/multimap": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+			"integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+			"dev": true
 		},
 		"node_modules/mute-stream": {
 			"version": "0.0.8",
@@ -27894,6 +28857,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/pn": {
@@ -29976,6 +30948,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/regexp-tree": {
+			"version": "0.1.24",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+			"integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+			"dev": true,
+			"bin": {
+				"regexp-tree": "bin/regexp-tree"
+			}
+		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
@@ -30400,6 +31381,15 @@
 			"version": "2.0.0",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.5"
+			}
 		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
@@ -31552,6 +32542,74 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/smart-buffer": {
 			"version": "4.1.0",
 			"dev": true,
@@ -32589,14 +33647,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/stylelint/node_modules/astral-regex": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"dev": true,
@@ -32847,22 +33897,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/stylelint/node_modules/slice-ansi": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
 		"node_modules/stylelint/node_modules/string-width": {
@@ -34862,38 +35896,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/vscode-json-languageservice": {
-			"version": "3.11.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jsonc-parser": "^3.0.0",
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^5.0.0",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vscode-nls": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vscode-uri": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/vue": {
 			"version": "2.6.12",
@@ -39013,6 +40015,23 @@
 				"@hapi/hoek": "^8.3.0"
 			}
 		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
 		"@intervolga/optimize-cssnano-plugin": {
 			"version": "1.0.6",
 			"dev": true,
@@ -40483,6 +41502,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"@mdn/browser-compat-data": {
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+			"dev": true
+		},
 		"@mdx-js/loader": {
 			"version": "1.6.22",
 			"dev": true,
@@ -40627,6 +41652,12 @@
 			"version": "2.11.2",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
 			"integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+			"dev": true
+		},
+		"@rushstack/eslint-patch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz",
+			"integrity": "sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -44058,7 +45089,9 @@
 			}
 		},
 		"@wmde/eslint-config-wikimedia-typescript": {
-			"version": "0.2.0",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@wmde/eslint-config-wikimedia-typescript/-/eslint-config-wikimedia-typescript-0.2.2.tgz",
+			"integrity": "sha512-lgzW2LoqEItTD9rAV1jbj7QbRRvMwty1EHvSemSv8/y9MSJXbUk7hMgiGBfzAhS3Re/1zFVlM090Ep7gxcDoew==",
 			"dev": true,
 			"requires": {}
 		},
@@ -44516,6 +45549,15 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"dev": true
+		},
+		"ast-metadata-inferer": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+			"integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+			"dev": true,
+			"requires": {
+				"@mdn/browser-compat-data": "^3.3.14"
+			}
 		},
 		"ast-types": {
 			"version": "0.14.2",
@@ -46407,6 +47449,15 @@
 					"version": "0.6.1",
 					"dev": true
 				}
+			}
+		},
+		"clean-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"clean-stack": {
@@ -48864,73 +49915,610 @@
 			}
 		},
 		"eslint-config-wikimedia": {
-			"version": "0.16.2",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.21.0.tgz",
+			"integrity": "sha512-+KoUKaWSKTgIx+Run9gdbGXi6Uox2/JxgROTVmA6yi4mnMuFWwpBXzYFjqZPUT7dzmJSTO3uxwsR44F8GnZhpg==",
 			"dev": true,
 			"requires": {
-				"eslint": "^7.2.0",
-				"eslint-plugin-es": "^3.0.1",
-				"eslint-plugin-jsdoc": "^27.1.2",
-				"eslint-plugin-json": "^2.1.1",
-				"eslint-plugin-mediawiki": "^0.2.5",
-				"eslint-plugin-mocha": "^7.0.1",
-				"eslint-plugin-no-jquery": "^2.4.1",
+				"eslint": "^7.32.0",
+				"eslint-plugin-compat": "^3.13.0",
+				"eslint-plugin-es": "^4.1.0",
+				"eslint-plugin-jsdoc": "^37.0.3",
+				"eslint-plugin-json-es": "^1.5.4",
+				"eslint-plugin-mediawiki": "^0.3.0",
+				"eslint-plugin-mocha": "^9.0.0",
+				"eslint-plugin-no-jquery": "^2.7.0",
 				"eslint-plugin-node": "^11.1.0",
-				"eslint-plugin-qunit": "^4.2.0",
-				"eslint-plugin-vue": "^6.2.2",
-				"eslint-plugin-wdio": "^6.0.12"
+				"eslint-plugin-qunit": "^7.0.0",
+				"eslint-plugin-unicorn": "^37.0.1",
+				"eslint-plugin-vue": "^8.0.2",
+				"eslint-plugin-wdio": "^7.4.2"
 			},
 			"dependencies": {
-				"comment-parser": {
-					"version": "0.7.6",
-					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
-					"integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
-					"dev": true
-				},
-				"eslint-plugin-jsdoc": {
-					"version": "27.1.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-27.1.2.tgz",
-					"integrity": "sha512-iWrG2ZK4xrxamoMkoyzgkukdmfqWc5Ncd6K+CnwRgxrbwjQQpzmt5Kl8GB0l12R0oUK2AF+9tGFJKNGzuyz79Q==",
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
-						"comment-parser": "^0.7.5",
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@eslint/eslintrc": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+					"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.12.4",
 						"debug": "^4.1.1",
-						"jsdoctypeparser": "^6.1.0",
-						"lodash": "^4.17.15",
-						"regextras": "^0.7.1",
-						"semver": "^6.3.0",
-						"spdx-expression-parse": "^3.0.1"
+						"espree": "^7.3.0",
+						"globals": "^13.9.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.2.1",
+						"js-yaml": "^3.13.1",
+						"minimatch": "^3.0.4",
+						"strip-json-comments": "^3.1.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"ci-info": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+					"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
+				"eslint": {
+					"version": "7.32.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+					"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.12.11",
+						"@eslint/eslintrc": "^0.4.3",
+						"@humanwhocodes/config-array": "^0.5.0",
+						"ajv": "^6.10.0",
+						"chalk": "^4.0.0",
+						"cross-spawn": "^7.0.2",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"enquirer": "^2.3.5",
+						"escape-string-regexp": "^4.0.0",
+						"eslint-scope": "^5.1.1",
+						"eslint-utils": "^2.1.0",
+						"eslint-visitor-keys": "^2.0.0",
+						"espree": "^7.3.1",
+						"esquery": "^1.4.0",
+						"esutils": "^2.0.2",
+						"fast-deep-equal": "^3.1.3",
+						"file-entry-cache": "^6.0.1",
+						"functional-red-black-tree": "^1.0.1",
+						"glob-parent": "^5.1.2",
+						"globals": "^13.6.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
+						"imurmurhash": "^0.1.4",
+						"is-glob": "^4.0.0",
+						"js-yaml": "^3.13.1",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.4.1",
+						"lodash.merge": "^4.6.2",
+						"minimatch": "^3.0.4",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.9.1",
+						"progress": "^2.0.0",
+						"regexpp": "^3.1.0",
+						"semver": "^7.2.1",
+						"strip-ansi": "^6.0.0",
+						"strip-json-comments": "^3.1.0",
+						"table": "^6.0.9",
+						"text-table": "^0.2.0",
+						"v8-compile-cache": "^2.0.3"
+					}
+				},
+				"eslint-plugin-es": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+					"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+					"dev": true,
+					"requires": {
+						"eslint-utils": "^2.0.0",
+						"regexpp": "^3.0.0"
+					}
+				},
+				"eslint-plugin-unicorn": {
+					"version": "37.0.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
+					"integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"ci-info": "^3.2.0",
+						"clean-regexp": "^1.0.0",
+						"eslint-template-visitor": "^2.3.2",
+						"eslint-utils": "^3.0.0",
+						"esquery": "^1.4.0",
+						"indent-string": "4",
+						"is-builtin-module": "^3.1.0",
+						"lodash": "^4.17.21",
+						"pluralize": "^8.0.0",
+						"read-pkg-up": "^7.0.1",
+						"regexp-tree": "^0.1.23",
+						"safe-regex": "^2.1.1",
+						"semver": "^7.3.5",
+						"strip-indent": "^3.0.0"
+					},
+					"dependencies": {
+						"eslint-template-visitor": {
+							"version": "2.3.2",
+							"resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+							"integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+							"dev": true,
+							"requires": {
+								"@babel/core": "^7.12.16",
+								"@babel/eslint-parser": "^7.12.16",
+								"eslint-visitor-keys": "^2.0.0",
+								"esquery": "^1.3.1",
+								"multimap": "^1.1.0"
+							},
+							"dependencies": {
+								"@babel/eslint-parser": {
+									"version": "7.17.0",
+									"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+									"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+									"dev": true,
+									"requires": {
+										"eslint-scope": "^5.1.1",
+										"eslint-visitor-keys": "^2.1.0",
+										"semver": "^6.3.0"
+									}
+								},
+								"semver": {
+									"version": "6.3.0",
+									"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+									"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+									"dev": true
+								}
+							}
+						},
+						"eslint-utils": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+							"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+							"dev": true,
+							"requires": {
+								"eslint-visitor-keys": "^2.0.0"
+							}
+						}
 					}
 				},
 				"eslint-plugin-vue": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-					"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.5.0.tgz",
+					"integrity": "sha512-i1uHCTAKOoEj12RDvdtONWrGzjFm/djkzqfhmQ0d6M/W8KM81mhswd/z+iTZ0jCpdUedW3YRgcVfQ37/J4zoYQ==",
 					"dev": true,
 					"requires": {
+						"eslint-utils": "^3.0.0",
 						"natural-compare": "^1.4.0",
-						"semver": "^5.6.0",
-						"vue-eslint-parser": "^7.0.0"
+						"semver": "^7.3.5",
+						"vue-eslint-parser": "^8.0.1"
 					},
 					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+						"acorn": {
+							"version": "8.7.0",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+							"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+							"dev": true
+						},
+						"eslint-scope": {
+							"version": "7.1.1",
+							"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+							"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+							"dev": true,
+							"requires": {
+								"esrecurse": "^4.3.0",
+								"estraverse": "^5.2.0"
+							}
+						},
+						"eslint-utils": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+							"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+							"dev": true,
+							"requires": {
+								"eslint-visitor-keys": "^2.0.0"
+							}
+						},
+						"espree": {
+							"version": "9.3.1",
+							"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+							"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+							"dev": true,
+							"requires": {
+								"acorn": "^8.7.0",
+								"acorn-jsx": "^5.3.1",
+								"eslint-visitor-keys": "^3.3.0"
+							},
+							"dependencies": {
+								"eslint-visitor-keys": {
+									"version": "3.3.0",
+									"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+									"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+									"dev": true
+								}
+							}
+						},
+						"estraverse": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+							"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+							"dev": true
+						},
+						"vue-eslint-parser": {
+							"version": "8.3.0",
+							"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz",
+							"integrity": "sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==",
+							"dev": true,
+							"requires": {
+								"debug": "^4.3.2",
+								"eslint-scope": "^7.0.0",
+								"eslint-visitor-keys": "^3.1.0",
+								"espree": "^9.0.0",
+								"esquery": "^1.4.0",
+								"lodash": "^4.17.21",
+								"semver": "^7.3.5"
+							},
+							"dependencies": {
+								"eslint-visitor-keys": {
+									"version": "3.3.0",
+									"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+									"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+									"dev": true
+								}
+							}
+						}
+					}
+				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
+				"espree": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+					"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.4.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^1.3.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 							"dev": true
 						}
 					}
 				},
-				"regextras": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
-					"integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+				"file-entry-cache": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+					"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^3.0.4"
+					}
+				},
+				"flat-cache": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+					"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+					"dev": true,
+					"requires": {
+						"flatted": "^3.1.0",
+						"rimraf": "^3.0.2"
+					}
+				},
+				"flatted": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+					"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 					"dev": true
 				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+				"globals": {
+					"version": "13.12.1",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+					"integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.20.2"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.20.2",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+							"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+							"dev": true
+						}
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"levn": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+					"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "^1.2.1",
+						"type-check": "~0.4.0"
+					}
+				},
+				"optionator": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+					"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+					"dev": true,
+					"requires": {
+						"deep-is": "^0.1.3",
+						"fast-levenshtein": "^2.0.6",
+						"levn": "^0.4.1",
+						"prelude-ls": "^1.2.1",
+						"type-check": "^0.4.0",
+						"word-wrap": "^1.2.3"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"prelude-ls": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+					"dev": true
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+					"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+					"dev": true,
+					"requires": {
+						"regexp-tree": "~0.1.1"
+					}
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"table": {
+					"version": "6.8.0",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+					"integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+					"dev": true,
+					"requires": {
+						"ajv": "^8.0.1",
+						"lodash.truncate": "^4.4.2",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "8.10.0",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+							"integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"json-schema-traverse": "^1.0.0",
+								"require-from-string": "^2.0.2",
+								"uri-js": "^4.2.2"
+							}
+						}
+					}
+				},
+				"type-check": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+					"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "^1.2.1"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -49054,6 +50642,61 @@
 				}
 			}
 		},
+		"eslint-plugin-compat": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.13.0.tgz",
+			"integrity": "sha512-cv8IYMuTXm7PIjMVDN2y4k/KVnKZmoNGHNq27/9dLstOLydKblieIv+oe2BN2WthuXnFNhaNvv3N1Bvl4dbIGA==",
+			"dev": true,
+			"requires": {
+				"@mdn/browser-compat-data": "^3.3.14",
+				"ast-metadata-inferer": "^0.7.0",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"core-js": "^3.16.2",
+				"find-up": "^5.0.0",
+				"lodash.memoize": "4.1.2",
+				"semver": "7.3.5"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				}
+			}
+		},
 		"eslint-plugin-es": {
 			"version": "3.0.1",
 			"dev": true,
@@ -49148,57 +50791,96 @@
 				}
 			}
 		},
-		"eslint-plugin-json": {
-			"version": "2.1.2",
+		"eslint-plugin-json-es": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.4.tgz",
+			"integrity": "sha512-DdjnNMUZ1iMrUXfxUQrTU7IyoEOsa4Kg0Zd6nOyOq1mUb75deK7NrcbI1FlWGdGVgqX99bUOD27i81EYiG794Q==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.19",
-				"vscode-json-languageservice": "^3.7.0"
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.7.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+					"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+					"dev": true
+				},
+				"eslint-visitor-keys": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"dev": true
+				},
+				"espree": {
+					"version": "9.3.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+					"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.7.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^3.3.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-mediawiki": {
-			"version": "0.2.6",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.3.0.tgz",
+			"integrity": "sha512-Lhyj2PSkhDzYSc1PNbURysY/WoqvY0brw558ZInT3erzf5KUlro18MTKFdV+nlht475ZgnsfHsgfg6Ut2w1SVg==",
 			"dev": true,
 			"requires": {
-				"eslint-plugin-vue": "^6.2.2",
-				"upath": "^1.2.0"
+				"eslint-plugin-vue": "^7.20.0",
+				"upath": "^2.0.1"
 			},
 			"dependencies": {
-				"eslint-plugin-vue": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-					"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
-					"dev": true,
-					"requires": {
-						"natural-compare": "^1.4.0",
-						"semver": "^5.6.0",
-						"vue-eslint-parser": "^7.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+				"upath": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+					"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-mocha": {
-			"version": "7.0.1",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
+			"integrity": "sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==",
 			"dev": true,
 			"requires": {
-				"eslint-utils": "^2.0.0",
-				"ramda": "^0.27.0"
+				"eslint-utils": "^3.0.0",
+				"ramda": "^0.27.1"
 			},
 			"dependencies": {
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
 				"ramda": {
-					"version": "0.27.1",
+					"version": "0.27.2",
+					"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+					"integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-no-jquery": {
-			"version": "2.5.0",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
+			"integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
 			"dev": true,
 			"requires": {}
 		},
@@ -49232,8 +50914,31 @@
 			"requires": {}
 		},
 		"eslint-plugin-qunit": {
-			"version": "4.3.0",
-			"dev": true
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.2.0.tgz",
+			"integrity": "sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^3.0.0",
+				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
+			}
 		},
 		"eslint-plugin-standard": {
 			"version": "5.0.0",
@@ -49270,7 +50975,9 @@
 			}
 		},
 		"eslint-plugin-wdio": {
-			"version": "6.6.0",
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-wdio/-/eslint-plugin-wdio-7.4.2.tgz",
+			"integrity": "sha512-tkISFycJmRFMKsEjetRcAmWSHKJKnw5rKHDxfE7Ob3tF5lbmYlCLfNKH0UwanOpSdulpe52s3K+CBHSd6qUUNQ==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -51946,6 +53653,23 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"dev": true
+		},
+		"is-builtin-module": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+			"integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "^3.0.0"
+			},
+			"dependencies": {
+				"builtin-modules": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+					"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+					"dev": true
+				}
+			}
 		},
 		"is-callable": {
 			"version": "1.2.4",
@@ -54628,12 +56352,6 @@
 			"integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
 			"dev": true
 		},
-		"jsdoctypeparser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
-			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
-			"dev": true
-		},
 		"jsdom": {
 			"version": "11.12.0",
 			"dev": true,
@@ -54718,10 +56436,6 @@
 			"requires": {
 				"minimist": "^1.2.5"
 			}
-		},
-		"jsonc-parser": {
-			"version": "3.0.0",
-			"dev": true
 		},
 		"jsonfile": {
 			"version": "2.4.0",
@@ -55708,6 +57422,12 @@
 		},
 		"multicast-dns-service-types": {
 			"version": "1.1.0",
+			"dev": true
+		},
+		"multimap": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+			"integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
 			"dev": true
 		},
 		"mute-stream": {
@@ -56817,6 +58537,12 @@
 			"requires": {
 				"find-up": "^4.0.0"
 			}
+		},
+		"pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true
 		},
 		"pn": {
 			"version": "1.1.0",
@@ -58410,6 +60136,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexp-tree": {
+			"version": "0.1.24",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+			"integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+			"dev": true
+		},
 		"regexp.prototype.flags": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
@@ -58703,6 +60435,12 @@
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
+			"dev": true
+		},
+		"requireindex": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
 			"dev": true
 		},
 		"requires-port": {
@@ -59505,6 +61243,55 @@
 			"version": "3.0.0",
 			"dev": true
 		},
+		"slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				}
+			}
+		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"dev": true
@@ -60196,10 +61983,6 @@
 						"color-convert": "^2.0.1"
 					}
 				},
-				"astral-regex": {
-					"version": "2.0.0",
-					"dev": true
-				},
 				"balanced-match": {
 					"version": "2.0.0",
 					"dev": true
@@ -60360,15 +62143,6 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"slice-ansi": {
-					"version": "4.0.0",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"astral-regex": "^2.0.0",
-						"is-fullwidth-code-point": "^3.0.0"
 					}
 				},
 				"string-width": {
@@ -61761,33 +63535,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
 			"integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
-			"dev": true
-		},
-		"vscode-json-languageservice": {
-			"version": "3.11.0",
-			"dev": true,
-			"requires": {
-				"jsonc-parser": "^3.0.0",
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-languageserver-types": "3.16.0-next.2",
-				"vscode-nls": "^5.0.0",
-				"vscode-uri": "^2.1.2"
-			}
-		},
-		"vscode-languageserver-textdocument": {
-			"version": "1.0.1",
-			"dev": true
-		},
-		"vscode-languageserver-types": {
-			"version": "3.16.0-next.2",
-			"dev": true
-		},
-		"vscode-nls": {
-			"version": "5.0.0",
-			"dev": true
-		},
-		"vscode-uri": {
-			"version": "2.1.2",
 			"dev": true
 		},
 		"vue": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -43,6 +43,7 @@
     "vue": "^2.6.12"
   },
   "devDependencies": {
+    "@rushstack/eslint-patch": "^1.1.0",
     "@storybook/addon-a11y": "~6.4.18",
     "@storybook/addon-backgrounds": "~6.4.18",
     "@storybook/addon-controls": "~6.4.18",
@@ -63,11 +64,11 @@
     "@vue/cli-service": "^4.5.15",
     "@vue/eslint-config-typescript": "^8.0.0",
     "@vue/test-utils": "^1.3.0",
-    "@wmde/eslint-config-wikimedia-typescript": "^0.2.0",
+    "@wmde/eslint-config-wikimedia-typescript": "^0.2.2",
     "chromatic": "^6.4.3",
     "chromedriver": "83",
     "eslint": "^7.13.0",
-    "eslint-config-wikimedia": "^0.16.2",
+    "eslint-config-wikimedia": "^0.21.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^37.8.2",

--- a/vue-components/src/components/Breakpoint.ts
+++ b/vue-components/src/components/Breakpoint.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-shadow
 enum Breakpoint {
 	Mobile = 'mobile',
 	Tablet = 'tablet',

--- a/vue-components/src/components/ResizeLimit.ts
+++ b/vue-components/src/components/ResizeLimit.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-shadow
 enum ResizeLimit {
 	Horizontal = 'horizontal',
 	Vertical = 'vertical',

--- a/vue-components/src/components/iconProps.ts
+++ b/vue-components/src/components/iconProps.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-shadow
 export enum IconTypes {
 	ADD = 'add',
 	ALERT = 'alert',
@@ -25,6 +26,7 @@ export const flippable = [
 	IconTypes.NEWWINDOW,
 ];
 
+// eslint-disable-next-line no-shadow
 export enum IconDirection {
 	RTL = 'rtl',
 	LTR = 'ltr'


### PR DESCRIPTION
Split out from #548 

This now also makes use of the Microsoft patch to eslint to work around the same problem already encountered previously in wmde/new-lexeme-special-page#74


Bug: T301155