### PR TITLE
Bump eslint config vue-root-class

### DIFF
--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -54,7 +54,7 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",
         "eslint-plugin-vue": "^7.0.0",
-        "eslint-plugin-vue-root-class": "^0.1.0",
+        "eslint-plugin-vue-root-class": "wmde/eslint-plugin-vue-root-class#bumpCompatibility",
         "geckodriver": "^1.19.1",
         "jest-axe": "^4.1.0",
         "jest-serializer-vue": "^2.0.2",
@@ -21134,9 +21134,9 @@
     },
     "node_modules/eslint-plugin-vue-root-class": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue-root-class/-/eslint-plugin-vue-root-class-0.1.0.tgz",
-      "integrity": "sha512-Ggw+IeoE2OZ8xMTirUWcrzZSVCgQz2YeaP6e2QVP93Rz8MrO/5h53AiQOoI1/Ix2qgpCvJ0gMlNUFX+CbdyXJA==",
+      "resolved": "git+ssh://git@github.com/wmde/eslint-plugin-vue-root-class.git#a77b60a9a6ac7b75866af30150ef733c547fa72f",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "vue-eslint-parser": "^7.1.1"
       },
@@ -21144,8 +21144,8 @@
         "node": ">=10.12.0"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0",
-        "vue": "^2.0.0"
+        "eslint": "^7.0.0||^8",
+        "vue": "^2.0.0||^3"
       }
     },
     "node_modules/eslint-plugin-wdio": {
@@ -56201,10 +56201,9 @@
       }
     },
     "eslint-plugin-vue-root-class": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue-root-class/-/eslint-plugin-vue-root-class-0.1.0.tgz",
-      "integrity": "sha512-Ggw+IeoE2OZ8xMTirUWcrzZSVCgQz2YeaP6e2QVP93Rz8MrO/5h53AiQOoI1/Ix2qgpCvJ0gMlNUFX+CbdyXJA==",
+      "version": "git+ssh://git@github.com/wmde/eslint-plugin-vue-root-class.git#a77b60a9a6ac7b75866af30150ef733c547fa72f",
       "dev": true,
+      "from": "eslint-plugin-vue-root-class@wmde/eslint-plugin-vue-root-class#bumpCompatibility",
       "requires": {
         "vue-eslint-parser": "^7.1.1"
       }

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^7.0.0",
-    "eslint-plugin-vue-root-class": "^0.1.0",
+    "eslint-plugin-vue-root-class": "wmde/eslint-plugin-vue-root-class#bumpCompatibility",
     "geckodriver": "^1.19.1",
     "jest-axe": "^4.1.0",
     "jest-serializer-vue": "^2.0.2",


### PR DESCRIPTION
This uses our fork until wiese/eslint-plugin-vue-root-class#5 is merged and a new version is released. This is needed as preparation for the upgrade to Eslint 8 and Vue 3