### PR TITLE
Replace `any` types in production code

### DIFF
--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { ComponentPublicInstance, defineComponent, PropType } from 'vue';
 import debounce from 'lodash/debounce';
 import { MenuItem } from './MenuItem';
 
@@ -156,8 +156,7 @@ export default defineComponent( {
 				this.maxHeight = null;
 			}
 		},
-		/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-		onScroll: debounce( function ( this: any ) {
+		onScroll: debounce( function ( this: ComponentPublicInstance ) {
 			const rootElem = this.$refs[ 'lookup-menu' ] as HTMLElement;
 			const menuItems = this.$refs[ 'menu-items' ] as HTMLElement[];
 			const menuTop = rootElem.scrollTop;

--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="[ 'wikit', 'wikit-TextInput', extraClasses ]" :style="(extraStyles as any)">
+	<div :class="[ 'wikit', 'wikit-TextInput', extraClasses ]" :style="extraStyles">
 		<span class="wikit-TextInput__label-wrapper">
 			<label
 				:class="[
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, StyleValue } from 'vue';
 import ValidationMessage from './ValidationMessage.vue';
 import Input from './Input.vue';
 import generateUid from '@/components/util/generateUid';
@@ -48,7 +48,7 @@ export default defineComponent( {
 		const { class: extraClasses, style: extraStyles, ...otherAttributes } = context.attrs;
 		return {
 			extraClasses,
-			extraStyles,
+			extraStyles: extraStyles as StyleValue,
 			otherAttributes,
 			feedbackType: computed( getFeedbackTypeFromProps( props ) ),
 		};


### PR DESCRIPTION
The `any` used for the `extraStyles` prop does not actually cause an
error when omitted and building wikit. However it does show up in
VSCode, probably because VSCode uses Volar internally which uses a more
advanced parser for vue files than @vue/cli. Still, it is unclear what
the right way forward here would be. So far, it seemed to not be
possible to type it as `StyleValue`, but maybe I just didn't find the
right place for it.