### PR TITLE
Bump premajor version to v3.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ _**Important:** This file contains a draft to the official release notes, and is
 not a stable documentation of the upcoming version (as it will frequently change during
 development)_
 
-## [Unreleased]
+###[Unreleased / 3.0.0]
+
+- Many components removed
+- upgrade to Vue 3
+
+###[Unreleased / 2.1.0]
 
 ### Added
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-docs",
-	"version": "2.1.0-alpha.11",
+	"version": "3.0.0-alpha.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@wmde/wikit-docs",
-			"version": "2.1.0-alpha.11",
+			"version": "3.0.0-alpha.0",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"traverse": "^0.6.6"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "2.1.0-alpha.11",
+  "version": "3.0.0-alpha.0",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist -s src/00-doc/static"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^2.1.0-alpha.11",
-    "@wmde/wikit-vue-components": "^2.1.0-alpha.11",
+    "@wmde/wikit-tokens": "^3.0.0-alpha.0",
+    "@wmde/wikit-vue-components": "^3.0.0-alpha.0",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "2.1.0-alpha.11"
+  "version": "3.0.0-alpha.0"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@wmde/wikit-tokens",
-			"version": "2.1.0-alpha.11",
+			"version": "3.0.0-alpha.0",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"eslint": "^7.13.0",

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/wikit-tokens",
-	"version": "2.1.0-alpha.11",
+	"version": "3.0.0-alpha.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "2.1.0-alpha.11",
+  "version": "3.0.0-alpha.0",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -12430,7 +12430,7 @@
       }
     },
     "node_modules/@wmde/wikit-tokens": {
-      "version": "2.1.0-alpha.12",
+      "version": "3.0.0-alpha.0",
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/ieee754": {
@@ -45028,7 +45028,7 @@
       "requires": {}
     },
     "@wmde/wikit-tokens": {
-      "version": "2.1.0-alpha.12"
+      "version": "3.0.0-alpha.0"
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@wmde/wikit-vue-components",
-      "version": "2.1.0-alpha.11",
+      "version": "3.0.0-alpha.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@wmde/wikit-tokens": "^2.1.0-alpha.11",
+        "@wmde/wikit-tokens": "^3.0.0-alpha.0",
         "core-js": "^3.7.0",
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "2.1.0-alpha.11",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "2.1.0-alpha.11",
+  "version": "3.0.0-alpha.0",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -34,7 +34,7 @@
   ],
   "types": "dist/main.d.ts",
   "dependencies": {
-    "@wmde/wikit-tokens": "^2.1.0-alpha.11",
+    "@wmde/wikit-tokens": "^3.0.0-alpha.0",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
As part of [#T303503](https://github.com/wmde/wikit/pull/557) we would like to use a Vue3 version of some of the Wikit components, created in the next branch.