### PR TITLE
Use node 16 in CI also for the release and prerelease workflows

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16'
       - name: Install
         run: npm ci
       - name: Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16'
       - name: Install
         run: npm ci
       - name: Test


### PR DESCRIPTION
These workflows failed with the error "npm ERR! fsevents not accessible from chokidar". On potential source of this error could be the node version mismatch between `.nvmrc` and the CI action.