### PR TITLE
Add missing `emits` to TextInput

### DIFF
--- a/vue-components/src/components/TextInput.vue
+++ b/vue-components/src/components/TextInput.vue
@@ -43,6 +43,7 @@ import { errorProp, ErrorProp, getFeedbackTypeFromProps } from '@/compositions/v
  */
 export default defineComponent( {
 	name: 'TextInput',
+	emits: [ 'input' ],
 	inheritAttrs: false,
 	setup( props: { error: ErrorProp }, context ) {
 		const { class: extraClasses, style: extraStyles, ...otherAttributes } = context.attrs;


### PR DESCRIPTION
All the other components (that haven’t been removed in this branch) already have the right `emits`, as far as I can tell.