### PR TITLE
Cherry pick "Generate Icon snapshot test cases using .each() (#578)"

### DIFF
--- a/vue-components/tests/unit/components/Icon.spec.ts
+++ b/vue-components/tests/unit/components/Icon.spec.ts
@@ -8,80 +8,12 @@ jest.mock( '@/components/util/generateUid', () => {
 
 describe( 'Icon', () => {
 
-	it( 'renders an error icon given type "error"', () => {
+	it.each(
+		Object.values( IconTypes ),
+	)( '%s: matches snapshot', ( iconType ) => {
 		const wrapper = mount( Icon, {
 			props: {
-				type: 'error',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders an alert icon given type "alert"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'alert',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders an edit icon given type "edit"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'edit',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders an error icon given type "trash"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'trash',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders a clear icon given type "clear"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'clear',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders a newwindow icon given type "newwindow"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'newwindow',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders a clear icon given type "link"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'link',
-			},
-		} );
-
-		expect( wrapper.element ).toMatchSnapshot();
-	} );
-
-	it( 'renders an outlined info icon given type "info-outlined"', () => {
-		const wrapper = mount( Icon, {
-			props: {
-				type: 'info-outlined',
+				type: iconType,
 			},
 		} );
 

--- a/vue-components/tests/unit/components/__snapshots__/Icon.spec.ts.snap
+++ b/vue-components/tests/unit/components/__snapshots__/Icon.spec.ts.snap
@@ -1,6 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Icon renders a clear icon given type "clear" 1`] = `
+exports[`Icon add: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 21 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M19.5444 8.5H12.0444V1H9.04443V8.5H1.54443V11.5H9.04443V19H12.0444V11.5H19.5444V8.5Z"
+      fill="currentColor"
+    />
+  </svg>
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon alert: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- alert icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon arrownext: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- arrownext icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8.59 3.42L14.17 9H2V11H14.17L8.59 16.59L10 18L18 10L10 2L8.59 3.42Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon arrowprevious: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- arrowprevious icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M5.83 9L11.41 3.42L10 2L2 10L10 18L11.41 16.59L5.83 11H18V9H5.83Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon checkmark: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- checkmark icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M6.34812 14.6259L1.6041 9.65425L0 11.3353L6.34812 18L20 3.693L18.3959 2L6.34812 14.6259Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon clear: matches snapshot 1`] = `
 <span
   class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
 >
@@ -26,7 +153,159 @@ exports[`Icon renders a clear icon given type "clear" 1`] = `
 </span>
 `;
 
-exports[`Icon renders a clear icon given type "link" 1`] = `
+exports[`Icon close: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- close icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M4.33999 2.92999L17.07 15.66L15.66 17.07L2.92999 4.34999L4.33999 2.92999Z"
+      fill="currentColor"
+    />
+    <path
+      d="M17.07 4.33999L4.33999 17.07L2.92999 15.66L15.66 2.92999L17.07 4.33999Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon edit: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- edit icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M16.77 8l1.94-2a1 1 0 000-1.41l-3.34-3.3a1 1 0 00-1.41 0L12 3.23zM1 14.25V19h4.75l9.96-9.96-4.75-4.75z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon error: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- error icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M11.4939 0H4.50612L0 4.50612V11.5102L4.50612 16H11.5102L16 11.4939V4.50612L11.4939 0Z
+					M8.8 11.9938H7.2V10.3999H8.8V11.9938Z
+					M8.8 9.6H7.2V4H8.8V9.6Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon info: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- info icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10 0C4.477 0 0 4.477 0 10C0 15.523 4.477 20 10 20C15.523 20 20 15.523 20 10C20 4.477 15.523 0 10 0ZM9 5H11V7H9V5ZM9 9H11V15H9V9Z"
+      fill="currentColor"
+    />
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon info-outlined: matches snapshot 1`] = `
+<span
+  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
+>
+  <!-- eslint-disable max-len -->
+  <!-- add icon -->
+  
+  <!-- info-outlined icon -->
+  <svg
+    aria-hidden="true"
+    class="wikit-Icon__svg"
+    fill="none"
+    focusable="false"
+    viewBox="0 0 20 21"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      clip-path="url(mockedID)"
+    >
+      <path
+        d="M10 19.1667C7.71324 19.1289 5.53071 18.2037 3.9135 16.5865C2.2963 14.9693 1.37109 12.7868 1.33334 10.5C1.37109 8.21324 2.2963 6.0307 3.9135 4.4135C5.53071 2.79629 7.71324 1.87108 10 1.83333C12.2868 1.87108 14.4693 2.79629 16.0865 4.4135C17.7037 6.0307 18.6289 8.21324 18.6667 10.5C18.6223 12.7846 17.695 14.9634 16.0792 16.5792C14.4634 18.195 12.2847 19.1223 10 19.1667ZM10 0.5C8.02219 0.5 6.08879 1.08649 4.4443 2.1853C2.79981 3.28412 1.51809 4.8459 0.761209 6.67316C0.00433286 8.50042 -0.1937 10.5111 0.192152 12.4509C0.578004 14.3907 1.53041 16.1725 2.92894 17.5711C4.32746 18.9696 6.10929 19.922 8.0491 20.3078C9.98891 20.6937 11.9996 20.4957 13.8268 19.7388C15.6541 18.9819 17.2159 17.7002 18.3147 16.0557C19.4135 14.4112 20 12.4778 20 10.5C20 7.84783 18.9464 5.3043 17.0711 3.42893C15.1957 1.55357 12.6522 0.5 10 0.5ZM10.6667 8.5V13.94H12V15.1667H8.09334V13.94H9.33334V9.83333H8V8.5H10.6667ZM9.33334 5.83333H10.6667V7.16667H9.33334V5.83333Z"
+        fill="currentColor"
+      />
+    </g>
+    <defs>
+      <clippath
+        id="mockedID"
+      >
+        <rect
+          fill="transparent"
+          height="20"
+          transform="translate(0 0.5)"
+          width="20"
+        />
+      </clippath>
+    </defs>
+  </svg>
+  
+  <!-- eslint-enable max-len -->
+</span>
+`;
+
+exports[`Icon link: matches snapshot 1`] = `
 <span
   class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
 >
@@ -71,7 +350,7 @@ exports[`Icon renders a clear icon given type "link" 1`] = `
 </span>
 `;
 
-exports[`Icon renders a newwindow icon given type "newwindow" 1`] = `
+exports[`Icon newwindow: matches snapshot 1`] = `
 <span
   class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
 >
@@ -101,40 +380,14 @@ exports[`Icon renders a newwindow icon given type "newwindow" 1`] = `
 </span>
 `;
 
-exports[`Icon renders an alert icon given type "alert" 1`] = `
+exports[`Icon search: matches snapshot 1`] = `
 <span
   class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
 >
   <!-- eslint-disable max-len -->
   <!-- add icon -->
   
-  <!-- alert icon -->
-  <svg
-    aria-hidden="true"
-    class="wikit-Icon__svg"
-    fill="none"
-    focusable="false"
-    viewBox="0 0 16 16"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z"
-      fill="currentColor"
-    />
-  </svg>
-  
-  <!-- eslint-enable max-len -->
-</span>
-`;
-
-exports[`Icon renders an edit icon given type "edit" 1`] = `
-<span
-  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
->
-  <!-- eslint-disable max-len -->
-  <!-- add icon -->
-  
-  <!-- edit icon -->
+  <!-- search icon -->
   <svg
     aria-hidden="true"
     class="wikit-Icon__svg"
@@ -144,7 +397,7 @@ exports[`Icon renders an edit icon given type "edit" 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M16.77 8l1.94-2a1 1 0 000-1.41l-3.34-3.3a1 1 0 00-1.41 0L12 3.23zM1 14.25V19h4.75l9.96-9.96-4.75-4.75z"
+      d="M7.5 13c3.04 0 5.5-2.46 5.5-5.5S10.54 2 7.5 2 2 4.46 2 7.5 4.46 13 7.5 13zm4.55.46A7.432 7.432 0 017.5 15C3.36 15 0 11.64 0 7.5S3.36 0 7.5 0C11.64 0 15 3.36 15 7.5c0 1.71-.57 3.29-1.54 4.55l6.49 6.49-1.41 1.41-6.49-6.49z"
       fill="currentColor"
     />
   </svg>
@@ -153,35 +406,7 @@ exports[`Icon renders an edit icon given type "edit" 1`] = `
 </span>
 `;
 
-exports[`Icon renders an error icon given type "error" 1`] = `
-<span
-  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
->
-  <!-- eslint-disable max-len -->
-  <!-- add icon -->
-  
-  <!-- error icon -->
-  <svg
-    aria-hidden="true"
-    class="wikit-Icon__svg"
-    fill="none"
-    focusable="false"
-    viewBox="0 0 16 16"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M11.4939 0H4.50612L0 4.50612V11.5102L4.50612 16H11.5102L16 11.4939V4.50612L11.4939 0Z
-					M8.8 11.9938H7.2V10.3999H8.8V11.9938Z
-					M8.8 9.6H7.2V4H8.8V9.6Z"
-      fill="currentColor"
-    />
-  </svg>
-  
-  <!-- eslint-enable max-len -->
-</span>
-`;
-
-exports[`Icon renders an error icon given type "trash" 1`] = `
+exports[`Icon trash: matches snapshot 1`] = `
 <span
   class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
 >
@@ -201,48 +426,6 @@ exports[`Icon renders an error icon given type "trash" 1`] = `
       d="M17 2H13.5L12.5 1H7.5L6.5 2H3V4H17V2ZM4 17C4 17.5304 4.21071 18.0391 4.58579 18.4142C4.96086 18.7893 5.46957 19 6 19H14C14.5304 19 15.0391 18.7893 15.4142 18.4142C15.7893 18.0391 16 17.5304 16 17V5H4V17Z"
       fill="currentColor"
     />
-  </svg>
-  
-  <!-- eslint-enable max-len -->
-</span>
-`;
-
-exports[`Icon renders an outlined info icon given type "info-outlined" 1`] = `
-<span
-  class="wikit wikit-Icon wikit-Icon--large wikit-Icon--base"
->
-  <!-- eslint-disable max-len -->
-  <!-- add icon -->
-  
-  <!-- info-outlined icon -->
-  <svg
-    aria-hidden="true"
-    class="wikit-Icon__svg"
-    fill="none"
-    focusable="false"
-    viewBox="0 0 20 21"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <g
-      clip-path="url(mockedID)"
-    >
-      <path
-        d="M10 19.1667C7.71324 19.1289 5.53071 18.2037 3.9135 16.5865C2.2963 14.9693 1.37109 12.7868 1.33334 10.5C1.37109 8.21324 2.2963 6.0307 3.9135 4.4135C5.53071 2.79629 7.71324 1.87108 10 1.83333C12.2868 1.87108 14.4693 2.79629 16.0865 4.4135C17.7037 6.0307 18.6289 8.21324 18.6667 10.5C18.6223 12.7846 17.695 14.9634 16.0792 16.5792C14.4634 18.195 12.2847 19.1223 10 19.1667ZM10 0.5C8.02219 0.5 6.08879 1.08649 4.4443 2.1853C2.79981 3.28412 1.51809 4.8459 0.761209 6.67316C0.00433286 8.50042 -0.1937 10.5111 0.192152 12.4509C0.578004 14.3907 1.53041 16.1725 2.92894 17.5711C4.32746 18.9696 6.10929 19.922 8.0491 20.3078C9.98891 20.6937 11.9996 20.4957 13.8268 19.7388C15.6541 18.9819 17.2159 17.7002 18.3147 16.0557C19.4135 14.4112 20 12.4778 20 10.5C20 7.84783 18.9464 5.3043 17.0711 3.42893C15.1957 1.55357 12.6522 0.5 10 0.5ZM10.6667 8.5V13.94H12V15.1667H8.09334V13.94H9.33334V9.83333H8V8.5H10.6667ZM9.33334 5.83333H10.6667V7.16667H9.33334V5.83333Z"
-        fill="currentColor"
-      />
-    </g>
-    <defs>
-      <clippath
-        id="mockedID"
-      >
-        <rect
-          fill="transparent"
-          height="20"
-          transform="translate(0 0.5)"
-          width="20"
-        />
-      </clippath>
-    </defs>
   </svg>
   
   <!-- eslint-enable max-len -->


### PR DESCRIPTION
This ensures that we test all the icon types for changes to the markup, not merely the ones where someone happened to add an explicit test case.