### PR TITLE
Add story for disabled focused Button (without fix)

### DIFF
--- a/vue-components/stories/Button.stories.ts
+++ b/vue-components/stories/Button.stories.ts
@@ -160,3 +160,24 @@ iconOnly.parameters = { docs: { storyDescription: `
 Please be aware that buttons that contain only an icon as a visual label require a textual label for screen readers.
 This can for example be implemented by using the [aria-label attribute](https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html).
 ` } };
+
+export function selfDisablingButton(): Component {
+	return {
+		compilerOptions: {
+			whitespace: 'preserve',
+		},
+		components: { Button },
+		data(): unknown {
+			return { disabled: false };
+		},
+		template: `
+			<div>
+				<Button variant="primary" type="progressive" :disabled="disabled" @click.native="disabled = true">
+					<span v-if="disabled">I am disabled.</span>
+					<span v-else>Disable me!</span>
+				</Button>
+				<Button @click.native="disabled = false">(re)enable the other one</Button>
+			</div>
+		`,
+	};
+}


### PR DESCRIPTION
In Firefox, clicking the first button does not make it appear disabled; only a second click will do that (it can be a click in the exact same place).

---

Tests behavior without #584 (see #585 for behavior with fix).