### PR TITLE
Add aria attributes for screen readers

### DIFF
--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -27,8 +27,7 @@
 			@input="$emit('input', $event)"
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
 			aria-autocomplete="list"
-			aria-haspopup="menu"
-			:aria-label="label"
+			aria-haspopup="listbox"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -26,8 +26,6 @@
 			@update:searchInput="$emit('update:searchInput', $event)"
 			@input="$emit('input', $event)"
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
-			aria-autocomplete="list"
-			aria-haspopup="listbox"
 			:label="label"
 		>
 			<template v-slot:no-results>

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -26,6 +26,9 @@
 			@update:searchInput="$emit('update:searchInput', $event)"
 			@input="$emit('input', $event)"
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
+			aria-autocomplete="list"
+			aria-haspopup="menu"
+			:aria-label="label"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -28,6 +28,7 @@
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
 			aria-autocomplete="list"
 			aria-haspopup="listbox"
+			:label="label"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -137,6 +137,11 @@ export default defineComponent( {
 		onInput( value: string ): void {
 			this.showMenu = this.canShowMenu( value );
 
+			// reset hover state id to reset aria-activedescendant
+			if ( value === '' ) {
+				this.keyboardHoverId = null;
+			}
+
 			// the following comment generates the event's description for the docs tab in storybook
 			/**
 			 * Enables the `searchInput` prop to be used with the `.sync` modifier. It's used to transport the value of

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -72,7 +72,7 @@ export default defineComponent( {
 			showMenu: false,
 			scrollIndexStart: null as ( number | null ),
 			scrollIndexEnd: null as ( number | null ),
-			keyboardHoverId: null,
+			keyboardHoverId: null as ( string | null ),
 			optionsMenuId: generateUid( 'wikit-OptionsMenu' ),
 		};
 	},

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -153,7 +153,6 @@ export default defineComponent( {
 		onFocus(): void {
 			if ( this.canShowMenu( this.searchInput ) ) {
 				this.showMenu = true;
-				this.$emit( 'expanded', true );
 			}
 		},
 		onEsc(): void {

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -29,6 +29,7 @@
 			ref="menu"
 			:aria-expanded="showMenu || 'false'"
 			:id="optionsMenuId"
+			:label="label"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />
@@ -114,6 +115,10 @@ export default defineComponent( {
 		 * computed property to dynamically update the Lookup's `menuItems` prop.
 		 */
 		searchInput: {
+			type: String,
+			default: '',
+		},
+		label: {
 			type: String,
 			default: '',
 		},

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -121,6 +121,10 @@ export default defineComponent( {
 			type: String,
 			default: '',
 		},
+		/**
+		 * Sets the label to be passed down to the inner `<OptionsMenu>` component so it can be properly announced
+		 * by screen readers.
+		 */
 		label: {
 			type: String,
 			default: '',

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -15,6 +15,8 @@
 			v-bind="$attrs"
 			:aria-activedescendant="keyboardHoverId"
 			:aria-owns="optionsMenuId"
+			aria-autocomplete="list"
+			aria-haspopup="listbox"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -7,7 +7,7 @@
 			:value="searchInput"
 			@input="onInput"
 			@focus.native="onFocus"
-			@blur.native="onBlurAndEsc"
+			@blur.native="showMenu = false"
 			:feedback-type="feedbackType"
 			:placeholder="placeholder"
 			:disabled="disabled"
@@ -28,7 +28,7 @@
 			v-show="showMenu"
 			@select="onSelect"
 			@scroll="onScroll"
-			@esc="onBlurAndEsc"
+			@esc="onEsc"
 			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
 			:id="optionsMenuId"
@@ -162,7 +162,7 @@ export default defineComponent( {
 				this.showMenu = true;
 			}
 		},
-		onBlurAndEsc(): void {
+		onEsc(): void {
 			this.showMenu = false;
 			this.keyboardHoverId = null;
 		},

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -13,6 +13,8 @@
 			:disabled="disabled"
 			autocomplete="off"
 			v-bind="$attrs"
+			:aria-owns="keyboardHoverIndex > -1 ? `menu-item-${keyboardHoverIndex}` : ''"
+			:aria-activedescendant="keyboardHoverIndex > -1 ? `menu-item-${keyboardHoverIndex}` : ''"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"
@@ -23,6 +25,7 @@
 			@select="onSelect"
 			@scroll="onScroll"
 			@esc="onEsc"
+			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
 		>
 			<template v-slot:no-results>
@@ -66,6 +69,7 @@ export default defineComponent( {
 			showMenu: false,
 			scrollIndexStart: null as ( number | null ),
 			scrollIndexEnd: null as ( number | null ),
+			keyboardHoverIndex: -1,
 		};
 	},
 	props: {
@@ -140,6 +144,7 @@ export default defineComponent( {
 		onFocus(): void {
 			if ( this.canShowMenu( this.searchInput ) ) {
 				this.showMenu = true;
+				this.$emit( 'expanded', true );
 			}
 		},
 		onEsc(): void {
@@ -158,6 +163,9 @@ export default defineComponent( {
 				this.scrollIndexEnd = lastIndex;
 			}
 
+		},
+		onKeyboardHoverChange( index: number ): void {
+			this.keyboardHoverIndex = index;
 		},
 	},
 	computed: {

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -17,6 +17,8 @@
 			:aria-owns="optionsMenuId"
 			aria-autocomplete="list"
 			aria-haspopup="listbox"
+			:aria-expanded="showMenu || 'false'"
+			role="combobox"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"
@@ -31,7 +33,6 @@
 			ref="menu"
 			:id="optionsMenuId"
 			:label="label"
-			:aria-expanded="showMenu || 'false'"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -14,6 +14,7 @@
 			autocomplete="off"
 			v-bind="$attrs"
 			:aria-owns="optionsMenuId"
+			:aria-expanded="showMenu || 'false'"
 			:aria-activedescendant="keyboardHoverId"
 		/>
 		<OptionsMenu
@@ -27,7 +28,6 @@
 			@esc="onEsc"
 			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
-			:aria-expanded="showMenu || 'false'"
 			:id="optionsMenuId"
 			:label="label"
 		>

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -7,7 +7,7 @@
 			:value="searchInput"
 			@input="onInput"
 			@focus.native="onFocus"
-			@blur.native="showMenu = false"
+			@blur.native="onBlurAndEsc"
 			:feedback-type="feedbackType"
 			:placeholder="placeholder"
 			:disabled="disabled"
@@ -28,7 +28,7 @@
 			v-show="showMenu"
 			@select="onSelect"
 			@scroll="onScroll"
-			@esc="onEsc"
+			@esc="onBlurAndEsc"
 			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
 			:id="optionsMenuId"
@@ -162,7 +162,7 @@ export default defineComponent( {
 				this.showMenu = true;
 			}
 		},
-		onEsc(): void {
+		onBlurAndEsc(): void {
 			this.showMenu = false;
 			this.keyboardHoverId = null;
 		},

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -13,8 +13,6 @@
 			:disabled="disabled"
 			autocomplete="off"
 			v-bind="$attrs"
-			:aria-owns="optionsMenuId"
-			:aria-expanded="showMenu || 'false'"
 			:aria-activedescendant="keyboardHoverId"
 		/>
 		<OptionsMenu
@@ -30,6 +28,8 @@
 			ref="menu"
 			:id="optionsMenuId"
 			:label="label"
+			:aria-owns="optionsMenuId"
+			:aria-expanded="showMenu || 'false'"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -14,6 +14,7 @@
 			autocomplete="off"
 			v-bind="$attrs"
 			:aria-activedescendant="keyboardHoverId"
+			:aria-owns="optionsMenuId"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"
@@ -28,7 +29,6 @@
 			ref="menu"
 			:id="optionsMenuId"
 			:label="label"
-			:aria-owns="optionsMenuId"
 			:aria-expanded="showMenu || 'false'"
 		>
 			<template v-slot:no-results>

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -137,11 +137,6 @@ export default defineComponent( {
 		onInput( value: string ): void {
 			this.showMenu = this.canShowMenu( value );
 
-			// reset hover state id to reset aria-activedescendant
-			if ( value === '' ) {
-				this.keyboardHoverId = null;
-			}
-
 			// the following comment generates the event's description for the docs tab in storybook
 			/**
 			 * Enables the `searchInput` prop to be used with the `.sync` modifier. It's used to transport the value of

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -13,8 +13,8 @@
 			:disabled="disabled"
 			autocomplete="off"
 			v-bind="$attrs"
-			:aria-owns="keyboardHoverIndex > -1 ? `menu-item-${keyboardHoverIndex}` : ''"
-			:aria-activedescendant="keyboardHoverIndex > -1 ? `menu-item-${keyboardHoverIndex}` : ''"
+			:aria-owns="optionsMenuId"
+			:aria-activedescendant="keyboardHoverId"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"
@@ -27,6 +27,8 @@
 			@esc="onEsc"
 			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
+			:aria-expanded="showMenu || 'false'"
+			:id="optionsMenuId"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />
@@ -40,6 +42,7 @@ import Vue from 'vue';
 import Input from '@/components/Input.vue';
 import OptionsMenu from '@/components/OptionsMenu.vue';
 import isEqual from 'lodash.isequal';
+import generateUid from '@/components/util/generateUid';
 import VueCompositionAPI, { defineComponent, ref } from '@vue/composition-api';
 import { MenuItem } from '@/components/MenuItem';
 
@@ -69,7 +72,8 @@ export default defineComponent( {
 			showMenu: false,
 			scrollIndexStart: null as ( number | null ),
 			scrollIndexEnd: null as ( number | null ),
-			keyboardHoverIndex: -1,
+			keyboardHoverId: null,
+			optionsMenuId: generateUid( 'wikit-OptionsMenu' ),
 		};
 	},
 	props: {
@@ -149,6 +153,7 @@ export default defineComponent( {
 		},
 		onEsc(): void {
 			this.showMenu = false;
+			this.keyboardHoverId = null;
 		},
 		onScroll( firstIndex: number, lastIndex: number ): void {
 			if ( firstIndex !== this.scrollIndexStart || lastIndex !== this.scrollIndexEnd ) {
@@ -164,8 +169,8 @@ export default defineComponent( {
 			}
 
 		},
-		onKeyboardHoverChange( index: number ): void {
-			this.keyboardHoverIndex = index;
+		onKeyboardHoverChange( menuItemId: string ): void {
+			this.keyboardHoverId = menuItemId;
 		},
 	},
 	computed: {

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -23,6 +23,7 @@
 			role="option"
 			:aria-label="`${menuItem.label} - ${menuItem.description}`"
 			:id="`${menuItemId}-${index}`"
+			:aria-selected="index === selectedItemIndex || 'false'"
 		>
 			<div class="wikit-OptionsMenu__item__label-wrapper">
 				<div

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -118,9 +118,6 @@ export default Vue.extend( {
 					} else {
 						this.keyboardHoveredItemIndex = Math.max( 0, this.keyboardHoveredItemIndex - 1 );
 					}
-					if ( this.keyboardHoveredItemIndex > -1 ) {
-						this.$emit( 'keyboard-hover-change', `${this.menuItemId}-${this.keyboardHoveredItemIndex}` );
-					}
 					this.keyboardScroll();
 					break;
 				case 'ArrowDown':
@@ -133,9 +130,6 @@ export default Vue.extend( {
 							this.menuItems.length - 1,
 							this.keyboardHoveredItemIndex + 1,
 						);
-					}
-					if ( this.keyboardHoveredItemIndex > -1 ) {
-						this.$emit( 'keyboard-hover-change', `${this.menuItemId}-${this.keyboardHoveredItemIndex}` );
 					}
 					this.keyboardScroll();
 					break;
@@ -201,6 +195,13 @@ export default Vue.extend( {
 			await this.$nextTick();
 			this.keyboardHoveredItemIndex = this.selectedItemIndex;
 			this.resizeMenu();
+		},
+		keyboardHoveredItemIndex( hoveredIndex: number ): void {
+			if ( hoveredIndex > -1 ) {
+				this.$emit( 'keyboard-hover-change', `${this.menuItemId}-${hoveredIndex}` );
+			} else {
+				this.$emit( 'keyboard-hover-change', null );
+			}
 		},
 	},
 } );

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -21,8 +21,7 @@
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
 			role="option"
-			:aria-label="menuItem.label"
-			:aria-description="menuItem.description"
+			:aria-label="`${menuItem.label} - ${menuItem.description}`"
 			:id="`${menuItemId}-${index}`"
 		>
 			<div class="wikit-OptionsMenu__item__label-wrapper">

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -21,7 +21,8 @@
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
 			role="option"
-			:aria-label="`${menuItem.label} - ${menuItem.description}`"
+			:aria-label="menuItem.label"
+			:aria-describedby="`${menuItemId}__description-${index}`"
 			:id="`${menuItemId}-${index}`"
 			:aria-selected="index === selectedItemIndex || 'false'"
 		>
@@ -38,7 +39,7 @@
 					{{ menuItem.tag }}
 				</div>
 			</div>
-			<div class="wikit-OptionsMenu__item__description">
+			<div class="wikit-OptionsMenu__item__description" :id="`${menuItemId}__description-${index}`">
 				{{ menuItem.description }}
 			</div>
 		</div>

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -42,7 +42,7 @@
 				{{ menuItem.description }}
 			</div>
 		</div>
-		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results">
+		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results" role="alert">
 			<slot name="no-results" />
 		</div>
 	</div>

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -3,6 +3,8 @@
 		:class="[ 'wikit', 'wikit-OptionsMenu' ]"
 		@scroll.passive="onScroll"
 		ref="lookup-menu"
+		role="menu"
+		:aria-expanded="showMenu || 'false'"
 		:style="{ maxHeight: maxHeight ? maxHeight + 'px' : null }"
 	>
 		<div
@@ -18,6 +20,9 @@
 			@mousedown.prevent="activeItemIndex = index"
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
+			role="menuitem"
+			:aria-label="`${menuItem.label} - ${menuItem.description}`"
+			:id="`menu-item-${index}`"
 		>
 			<div class="wikit-OptionsMenu__item__label-wrapper">
 				<div
@@ -105,7 +110,9 @@ export default Vue.extend( {
 					} else {
 						this.keyboardHoveredItemIndex = Math.max( 0, this.keyboardHoveredItemIndex - 1 );
 					}
-
+					if ( this.keyboardHoveredItemIndex > -1 ) {
+						this.$emit( 'keyboard-hover-change', this.keyboardHoveredItemIndex );
+					}
 					this.keyboardScroll();
 					break;
 				case 'ArrowDown':
@@ -118,6 +125,9 @@ export default Vue.extend( {
 							this.menuItems.length - 1,
 							this.keyboardHoveredItemIndex + 1,
 						);
+					}
+					if ( this.keyboardHoveredItemIndex > -1 ) {
+						this.$emit( 'keyboard-hover-change', this.keyboardHoveredItemIndex );
 					}
 					this.keyboardScroll();
 					break;

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -3,9 +3,9 @@
 		:class="[ 'wikit', 'wikit-OptionsMenu' ]"
 		@scroll.passive="onScroll"
 		ref="lookup-menu"
-		role="menu"
-		:aria-expanded="showMenu || 'false'"
+		role="listbox"
 		:style="{ maxHeight: maxHeight ? maxHeight + 'px' : null }"
+		aria-label="Options Menu"
 	>
 		<div
 			class="wikit-OptionsMenu__item"
@@ -20,9 +20,9 @@
 			@mousedown.prevent="activeItemIndex = index"
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
-			role="menuitem"
+			role="option"
 			:aria-label="`${menuItem.label} - ${menuItem.description}`"
-			:id="`menu-item-${index}`"
+			:id="`${menuItemId}-${index}`"
 		>
 			<div class="wikit-OptionsMenu__item__label-wrapper">
 				<div
@@ -50,6 +50,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import debounce from 'lodash/debounce';
+import generateUid from '@/components/util/generateUid';
 
 /**
  * This is an internal component which used by the Lookup component.
@@ -61,6 +62,7 @@ export default Vue.extend( {
 			maxHeight: null as number|null,
 			activeItemIndex: -1,
 			keyboardHoveredItemIndex: -1,
+			menuItemId: generateUid( 'wikit-OptionsMenu__item__id' ),
 		};
 	},
 	props: {
@@ -111,7 +113,7 @@ export default Vue.extend( {
 						this.keyboardHoveredItemIndex = Math.max( 0, this.keyboardHoveredItemIndex - 1 );
 					}
 					if ( this.keyboardHoveredItemIndex > -1 ) {
-						this.$emit( 'keyboard-hover-change', this.keyboardHoveredItemIndex );
+						this.$emit( 'keyboard-hover-change', `${this.menuItemId}-${this.keyboardHoveredItemIndex}` );
 					}
 					this.keyboardScroll();
 					break;
@@ -127,7 +129,7 @@ export default Vue.extend( {
 						);
 					}
 					if ( this.keyboardHoveredItemIndex > -1 ) {
-						this.$emit( 'keyboard-hover-change', this.keyboardHoveredItemIndex );
+						this.$emit( 'keyboard-hover-change', `${this.menuItemId}-${this.keyboardHoveredItemIndex}` );
 					}
 					this.keyboardScroll();
 					break;

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -43,7 +43,7 @@
 				{{ menuItem.description }}
 			</div>
 		</div>
-		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results" role="alert">
+		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results">
 			<slot name="no-results" />
 		</div>
 	</div>

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -21,7 +21,8 @@
 			@mouseup="activeItemIndex = -1"
 			ref="menu-items"
 			role="option"
-			:aria-label="`${menuItem.label} - ${menuItem.description}`"
+			:aria-label="menuItem.label"
+			:aria-description="menuItem.description"
 			:id="`${menuItemId}-${index}`"
 		>
 			<div class="wikit-OptionsMenu__item__label-wrapper">

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -5,7 +5,7 @@
 		ref="lookup-menu"
 		role="listbox"
 		:style="{ maxHeight: maxHeight ? maxHeight + 'px' : null }"
-		aria-label="Options Menu"
+		:aria-label="label"
 	>
 		<div
 			class="wikit-OptionsMenu__item"
@@ -90,6 +90,10 @@ export default Vue.extend( {
 		allowLooping: {
 			type: Boolean,
 			default: false,
+		},
+		label: {
+			type: String,
+			default: '',
 		},
 	},
 	methods: {

--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -22,7 +22,7 @@
 			ref="menu-items"
 			role="option"
 			:aria-label="menuItem.label"
-			:aria-describedby="`${menuItemId}__description-${index}`"
+			:aria-describedby="`${menuItemId}__description-${index} ${menuItemId}__tag-${index}`"
 			:id="`${menuItemId}-${index}`"
 			:aria-selected="index === selectedItemIndex || 'false'"
 		>
@@ -35,7 +35,7 @@
 				>
 					{{ menuItem.label }}
 				</div>
-				<div v-if="menuItem.tag" class="wikit-OptionsMenu__item__tag">
+				<div v-if="menuItem.tag" class="wikit-OptionsMenu__item__tag" :id="`${menuItemId}__tag-${index}`">
 					{{ menuItem.tag }}
 				</div>
 			</div>

--- a/vue-components/tests/a11y/AllComponents.spec.ts
+++ b/vue-components/tests/a11y/AllComponents.spec.ts
@@ -237,7 +237,8 @@ describe( 'OptionsMenu', () => {
 			{ label: 'potato', description: 'root vegetable' },
 			{ label: 'duck', description: 'aquatic bird' },
 		];
-		const wrapper = mount( OptionsMenu, { propsData: { menuItems } } );
+		const lookupLabel = 'Label of the parent Lookup';
+		const wrapper = mount( OptionsMenu, { propsData: { menuItems, label: lookupLabel } } );
 		const results = await axe( wrapper.element, {
 			rules: {
 				'region': { enabled: false },


### PR DESCRIPTION
Add more specific and complete aria attributes to allow screen
readers to announce menu and menu items correctly.

TODO:

- add role alert in a way that it is read by screen readers every time the 'no-results' panel is shown. the default behavior is that it is read only once if the text remains the same. This issue will be addressed in a follow-up PR.

Bug: [T290733](https://phabricator.wikimedia.org/T290733)