### PR TITLE
Update docs/ Storybook config

### DIFF
--- a/docs/.storybook/main.js
+++ b/docs/.storybook/main.js
@@ -1,6 +1,7 @@
 const path = require( 'path' );
 
 module.exports = {
+	staticDirs: [ '../src/00-doc/static' ],
 	stories: [ '../src/**/*.stories.@(js|mdx)' ],
 	addons: [
 		'@storybook/addon-a11y',

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,11 +18,11 @@
     "url": "git+https://github.com/wmde/wikit.git"
   },
   "scripts": {
-    "storybook": "start-storybook -s src/00-doc/static",
+    "storybook": "start-storybook",
     "test": "npm-run-all test:*",
     "test:lint": "eslint . --ext .js --ext .jsx --max-warnings 0",
     "fix": "npm run test:lint -- --fix",
-    "build": "build-storybook -o dist -s src/00-doc/static"
+    "build": "build-storybook -o dist"
   },
   "dependencies": {
     "@wmde/wikit-tokens": "^3.0.0-alpha.3",


### PR DESCRIPTION
--static-dir (-s) is deprecated since Storybook 6.4 [1].

[1]: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag