### PR TITLE
docs: Use React 16 instead of 17

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@wmde/wikit-docs",
-      "version": "3.0.0-alpha.2",
+      "version": "3.0.0-alpha.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@wmde/wikit-tokens": "^3.0.0-alpha.2",
-        "@wmde/wikit-vue-components": "^3.0.0-alpha.2",
+        "@wmde/wikit-tokens": "^3.0.0-alpha.3",
+        "@wmde/wikit-vue-components": "^3.0.0-alpha.3",
         "traverse": "^0.6.6"
       },
       "devDependencies": {
@@ -28,8 +28,7 @@
         "eslint-config-wikimedia": "^0.16.2",
         "eslint-plugin-react": "^7.21.5",
         "npm-run-all": "^4.1.5",
-        "react": "^17.0.0",
-        "react-is": "^17.0.0",
+        "react": "^16.14.0",
         "sass": "^1.43.3",
         "sass-loader": "^10"
       }
@@ -4600,20 +4599,6 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/@storybook/html/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@storybook/manager-webpack4": {
       "version": "6.4.19",
       "resolved": "https://registry.npmjs.org/@storybook/manager-webpack4/-/manager-webpack4-6.4.19.tgz",
@@ -6528,16 +6513,16 @@
       }
     },
     "node_modules/@wmde/wikit-tokens": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-YY1hAbvdwD2a6uIedZiBEo+JTVJY+mQhxyzBFX57ghZUT27siZ6XtW4DHNZBdmRH6QhM26fCySY8v9GpsRW98w=="
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-E+5elHujPueD81dNzOdHZs+pyuJqiFBq09hDR2uDNpI/B49kdzDh22JeWUJNABs3CIk8+eiP04+M9eAFyS8C7Q=="
     },
     "node_modules/@wmde/wikit-vue-components": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-SsTtG8vTSmUdwtHx0W+GVzuw7VNYN1Lnsyvihmiq2jeG7rMDDa4wsy+n5XL8Vj/P0e8C6/6yy91JYx90sHmP1g==",
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-7kDwx9DKosJfyixO0ctxHQypQbFHSTctJIffCBdVsk4r9vNdd77I14l64P3z+met0lXpSb9x4XXqkD/j2vnYqQ==",
       "dependencies": {
-        "@wmde/wikit-tokens": "^3.0.0-alpha.2",
+        "@wmde/wikit-tokens": "^3.0.0-alpha.3",
         "core-js": "^3.7.0",
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
@@ -16107,13 +16092,14 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -22600,7 +22586,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -23397,7 +23384,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "jest-worker": {
           "version": "27.5.1",
@@ -23448,7 +23436,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -24152,19 +24141,6 @@
         "read-pkg-up": "^7.0.1",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        }
       }
     },
     "@storybook/manager-webpack4": {
@@ -24562,7 +24538,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "jest-worker": {
           "version": "27.5.1",
@@ -24613,7 +24590,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -25723,16 +25701,16 @@
       }
     },
     "@wmde/wikit-tokens": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-YY1hAbvdwD2a6uIedZiBEo+JTVJY+mQhxyzBFX57ghZUT27siZ6XtW4DHNZBdmRH6QhM26fCySY8v9GpsRW98w=="
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-E+5elHujPueD81dNzOdHZs+pyuJqiFBq09hDR2uDNpI/B49kdzDh22JeWUJNABs3CIk8+eiP04+M9eAFyS8C7Q=="
     },
     "@wmde/wikit-vue-components": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-SsTtG8vTSmUdwtHx0W+GVzuw7VNYN1Lnsyvihmiq2jeG7rMDDa4wsy+n5XL8Vj/P0e8C6/6yy91JYx90sHmP1g==",
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-7kDwx9DKosJfyixO0ctxHQypQbFHSTctJIffCBdVsk4r9vNdd77I14l64P3z+met0lXpSb9x4XXqkD/j2vnYqQ==",
       "requires": {
-        "@wmde/wikit-tokens": "^3.0.0-alpha.2",
+        "@wmde/wikit-tokens": "^3.0.0-alpha.3",
         "core-js": "^3.7.0",
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
@@ -25772,13 +25750,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -25843,13 +25823,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -28685,7 +28667,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.7.0.tgz",
       "integrity": "sha512-Aeg7dA6GTH1AcWLlBtWNzOU9efK5KpNi7b0EhBO0o0M+awyzguUUo8gF6hXGjQ9n5h8/uRtYv9zOqQkeC5CG0w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-node": {
       "version": "11.1.0",
@@ -31480,7 +31463,8 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",
@@ -33230,20 +33214,22 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-colorful": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
       "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dom": {
       "version": "16.14.0",
@@ -35902,13 +35888,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -36782,7 +36770,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -36976,7 +36965,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,8 +47,7 @@
     "eslint-config-wikimedia": "^0.16.2",
     "eslint-plugin-react": "^7.21.5",
     "npm-run-all": "^4.1.5",
-    "react": "^17.0.0",
-    "react-is": "^17.0.0",
+    "react": "^16.14.0",
     "sass": "^1.43.3",
     "sass-loader": "^10"
   }


### PR DESCRIPTION
@storybook/html requires React 16 (though many other storybook packages are compatible with 16 || 17 || 18), and having multiple React versions in the tree seems to cause issues.

The explicit react-is dependency can be removed from package.json, we don’t use it directly. (It’s still pulled in by other packages.)