### PR TITLE
Cherry pick "Add aria attributes for screen readers (#587)"

### DIFF
--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -26,6 +26,7 @@
 			@update:searchInput="$emit('update:searchInput', $event)"
 			@input="$emit('input', $event)"
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
+			:label="label"
 		>
 			<template #no-results>
 				<slot name="no-results" />

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -13,6 +13,12 @@
 			:disabled="disabled"
 			autocomplete="off"
 			v-bind="$attrs"
+			:aria-activedescendant="keyboardHoverId"
+			:aria-owns="optionsMenuId"
+			aria-autocomplete="list"
+			aria-haspopup="listbox"
+			:aria-expanded="showMenu || 'false'"
+			role="combobox"
 		/>
 		<OptionsMenu
 			class="wikit-LookupInput__menu"
@@ -23,7 +29,10 @@
 			@select="onSelect"
 			@scroll="onScroll"
 			@esc="onEsc"
+			@keyboard-hover-change="onKeyboardHoverChange"
 			ref="menu"
+			:id="optionsMenuId"
+			:label="label"
 		>
 			<template #no-results>
 				<slot name="no-results" />
@@ -59,6 +68,11 @@ interface Props {
 	 * computed property to dynamically update the Lookup's `menuItems` prop.
 	 */
 	searchInput?: string;
+	/**
+	 * Sets the label to be passed down to the inner `<OptionsMenu>` component so it can be properly announced
+	 * by screen readers.
+	 */
+	label?: string;
 }
 
 const props = withDefaults( defineProps<Props>(), {
@@ -68,6 +82,7 @@ const props = withDefaults( defineProps<Props>(), {
 	placeholder: '',
 	value: null,
 	searchInput: '',
+	label: '',
 } );
 
 /**
@@ -113,8 +128,14 @@ function onSelect( menuItem: MenuItem ): void {
 	emit( 'update:searchInput', menuItem.label );
 }
 
+const keyboardHoverId = ref<string|null>( null );
 function onEsc(): void {
 	showMenu.value = false;
+	keyboardHoverId.value = null;
+}
+
+function onKeyboardHoverChange( menuItemId: string ): void {
+	keyboardHoverId.value = menuItemId;
 }
 
 const selectedItemIndex = computed( (): number => {
@@ -134,6 +155,7 @@ const selectedItemIndex = computed( (): number => {
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import generateUid from '@/components/util/generateUid';
 
 export default defineComponent( {
 	name: 'LookupInput',
@@ -143,6 +165,7 @@ export default defineComponent( {
 			showMenu: false,
 			scrollIndexStart: null as ( number | null ),
 			scrollIndexEnd: null as ( number | null ),
+			optionsMenuId: generateUid( 'wikit-OptionsMenu' ),
 		};
 	},
 	methods: {

--- a/vue-components/tests/a11y/AllComponents.spec.ts
+++ b/vue-components/tests/a11y/AllComponents.spec.ts
@@ -151,7 +151,8 @@ describe( 'OptionsMenu', () => {
 			{ label: 'potato', description: 'root vegetable' },
 			{ label: 'duck', description: 'aquatic bird' },
 		];
-		const wrapper = mount( OptionsMenu, { props: { menuItems } } );
+		const lookupLabel = 'Label of the parent Lookup';
+		const wrapper = mount( OptionsMenu, { propsData: { menuItems, label: lookupLabel } } );
 		const results = await axe( wrapper.element, {
 			rules: {
 				'region': { enabled: false },

--- a/vue-components/tests/a11y/AllComponents.spec.ts
+++ b/vue-components/tests/a11y/AllComponents.spec.ts
@@ -152,7 +152,7 @@ describe( 'OptionsMenu', () => {
 			{ label: 'duck', description: 'aquatic bird' },
 		];
 		const lookupLabel = 'Label of the parent Lookup';
-		const wrapper = mount( OptionsMenu, { propsData: { menuItems, label: lookupLabel } } );
+		const wrapper = mount( OptionsMenu, { props: { menuItems, label: lookupLabel } } );
 		const results = await axe( wrapper.element, {
 			rules: {
 				'region': { enabled: false },


### PR DESCRIPTION
Add more specific and complete aria attributes to allow screen
readers to announce menu and menu items correctly.

Note: adding an alert role that is read by screen readers every time the 'no-results' panel is shown is not implemented in this PR. the default behavior is that it is read only once if the text remains the same. This issue will be addressed in a follow-up PR.

Bug: T290733