### PR TITLE
Bump version to 3.0.0-alpha.5 (but properly)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wmde/wikit-docs",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wmde/wikit-docs",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@wmde/wikit-tokens": "^3.0.0-alpha.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmde/wikit-docs",
   "private": true,
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "Storybook for illustrating design tokens and components",
   "keywords": [
     "wikit",
@@ -25,8 +25,8 @@
     "build": "build-storybook -o dist"
   },
   "dependencies": {
-    "@wmde/wikit-tokens": "^3.0.0-alpha.4",
-    "@wmde/wikit-vue-components": "^3.0.0-alpha.4",
+    "@wmde/wikit-tokens": "^3.0.0-alpha.5",
+    "@wmde/wikit-vue-components": "^3.0.0-alpha.5",
     "traverse": "^0.6.6"
   },
   "bugs": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "vue-components",
     "docs"
   ],
-  "version": "3.0.0-alpha.4"
+  "version": "3.0.0-alpha.5"
 }

--- a/tokens/package-lock.json
+++ b/tokens/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wmde/wikit-tokens",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "eslint": "^8.17.0",

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-tokens",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "Design tokens for WiKit in different formats",
   "author": "The Wikidata team",
   "homepage": "https://github.com/wmde/wikit/tree/master/tokens#readme",

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wmde/wikit-vue-components",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@wmde/wikit-tokens": "^3.0.0-alpha.4",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/wikit-vue-components",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "The component implementation of WiKit in vue",
   "author": {
     "name": "The Wikidata team"
@@ -34,7 +34,7 @@
   ],
   "types": "dist/main.d.ts",
   "dependencies": {
-    "@wmde/wikit-tokens": "^3.0.0-alpha.4",
+    "@wmde/wikit-tokens": "^3.0.0-alpha.5",
     "core-js": "^3.7.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
npm run bump-version prerelease

Bug: [T290733](https://phabricator.wikimedia.org/T290733)