### PR TITLE
Cherry pick "Fix missing role on no-results slot (#602)"

### DIFF
--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -43,7 +43,7 @@
 				{{ menuItem.description }}
 			</div>
 		</div>
-		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results">
+		<div v-if="menuItems.length === 0" class="wikit-OptionsMenu__no-results" role="option">
 			<slot name="no-results" />
 		</div>
 	</div>


### PR DESCRIPTION
Follow-up to #587 and #599 respectively

Children of an element with a `role="listbox"` should have a
`role="option"`.
See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role

This resulted in an error in the cypress a11y check:

```
  NewLexemeForm
1 accessibility violation was detected
┌─────────┬──────────────────────────┬────────────┬────────────────────────────────────────────────────────────────────────────┬───────┐
│ (index) │            id            │   impact   │                                description                                 │ nodes │
├─────────┼──────────────────────────┼────────────┼────────────────────────────────────────────────────────────────────────────┼───────┤
│    0    │ 'aria-required-children' │ 'critical' │ 'Ensures elements with an ARIA role that require child roles contain them' │   1   │
└─────────┴──────────────────────────┴────────────┴────────────────────────────────────────────────────────────────────────────┴───────┘
```

See also https://dequeuniversity.com/rules/axe/4.4/aria-required-children?application=axeAPI