### PR TITLE
Add aria-required attribute to Lookup, LookupInput

### DIFF
--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -20,6 +20,7 @@
 			:feedback-type="feedbackType"
 			:menu-items="menuItems"
 			:disabled="disabled"
+			:aria-required="ariaRequired"
 			:placeholder="placeholder"
 			:value="value"
 			:search-input="searchInput"
@@ -94,6 +95,10 @@ export default defineComponent( {
 			default: (): [] => [],
 		},
 		disabled: {
+			type: Boolean,
+			default: false,
+		},
+		ariaRequired: {
 			type: Boolean,
 			default: false,
 		},

--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -18,6 +18,7 @@
 			aria-autocomplete="list"
 			aria-haspopup="listbox"
 			:aria-expanded="showMenu || 'false'"
+			:aria-required="ariaRequired ? 'true' : 'false'"
 			role="combobox"
 		/>
 		<OptionsMenu
@@ -55,6 +56,7 @@ interface Props {
 	 */
 	menuItems?: MenuItem[];
 	disabled?: boolean;
+	ariaRequired?: boolean;
 	placeholder?: string;
 	/**
 	 * The selected menu item
@@ -79,6 +81,7 @@ const props = withDefaults( defineProps<Props>(), {
 	feedbackType: null,
 	menuItems: (): [] => [],
 	disabled: false,
+	ariaRequired: false,
 	placeholder: '',
 	value: null,
 	searchInput: '',

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -75,6 +75,22 @@ describe( 'Lookup', () => {
 			expect( wrapper.find( 'input' ).attributes( 'disabled' ) ).toBe( '' );
 		} );
 
+		it( ':ariaRequired - not required by default', () => {
+			const wrapper = mount( Lookup );
+
+			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'false' );
+		} );
+
+		it( ':ariaRequired - can be required', () => {
+			const wrapper = mount( Lookup, {
+				props: {
+					ariaRequired: true,
+				},
+			} );
+
+			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'true' );
+		} );
+
 		it( ':placeholder - can have a placeholder', () => {
 			const placeholder = 'a placeholder';
 			const wrapper = mount( Lookup, {

--- a/vue-components/tests/unit/components/LookupCore.spec.ts
+++ b/vue-components/tests/unit/components/LookupCore.spec.ts
@@ -104,6 +104,22 @@ describe( 'LookupInput', () => {
 			expect( wrapper.find( 'input' ).attributes( 'disabled' ) ).toBe( '' );
 		} );
 
+		it( ':ariaRequired - not required by default', () => {
+			const wrapper = mount( LookupInput );
+
+			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'false' );
+		} );
+
+		it( ':ariaRequired - can be required', () => {
+			const wrapper = mount( LookupInput, {
+				props: {
+					ariaRequired: true,
+				},
+			} );
+
+			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'true' );
+		} );
+
 		it( ':placeholder - shows the placeholder in the input', () => {
 			const placeholder = 'a placeholder';
 			const wrapper = mount( LookupInput, {


### PR DESCRIPTION
We want to add this attribute to lookups on the new lexeme special page, and adding it to the surrounding `<div>` isn’t enough.

Bug: T313891