### PR TITLE
Apply full opacity to TextArea's placeholder

### DIFF
--- a/vue-components/src/components/TextArea.vue
+++ b/vue-components/src/components/TextArea.vue
@@ -267,6 +267,7 @@ export default defineComponent( {
 			font-weight: $wikit-Input-placeholder-font-weight;
 			line-height: $wikit-Input-placeholder-line-height;
 			color: $wikit-Input-placeholder-color;
+			opacity: $wikit-Input-placeholder-opacity;
 		}
 
 		&:disabled {


### PR DESCRIPTION
This is reusing the corresponding Input token, like we did with all other TextArea properties.

Related issue: [T312633](https://phabricator.wikimedia.org/T312633)