### PR TITLE
Let extra Lookup attributes fall trough to the <input> (#641)

### DIFF
--- a/vue-components/src/components/Lookup.vue
+++ b/vue-components/src/components/Lookup.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
-		:class="[ 'wikit', 'wikit-Lookup' ]"
+		:class="[ 'wikit', 'wikit-Lookup', extraClasses ]"
+		:style="extraStyles"
 	>
 		<span class="wikit-Lookup__label-wrapper">
 			<label
@@ -20,7 +21,6 @@
 			:feedback-type="feedbackType"
 			:menu-items="menuItems"
 			:disabled="disabled"
-			:aria-required="ariaRequired"
 			:placeholder="placeholder"
 			:value="value"
 			:search-input="searchInput"
@@ -28,6 +28,7 @@
 			@input="$emit('input', $event)"
 			@scroll="(firstIndex, lastIndex) => $emit('scroll', firstIndex, lastIndex)"
 			:label="label"
+			v-bind="otherAttributes"
 		>
 			<template v-slot:no-results>
 				<slot name="no-results" />
@@ -60,8 +61,13 @@ Vue.use( VueCompositionAPI );
  */
 export default defineComponent( {
 	name: 'Lookup',
-	setup( props: { error: ErrorProp } ) {
+	inheritAttrs: false,
+	setup( props: { error: ErrorProp }, context ) {
+		const { class: extraClasses, style: extraStyles, ...otherAttributes } = context.attrs;
 		return {
+			extraClasses,
+			extraStyles,
+			otherAttributes,
 			feedbackType: computed( getFeedbackTypeFromProps( props ) ),
 		};
 	},
@@ -80,10 +86,6 @@ export default defineComponent( {
 			default: (): [] => [],
 		},
 		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		ariaRequired: {
 			type: Boolean,
 			default: false,
 		},

--- a/vue-components/tests/unit/components/Lookup.spec.ts
+++ b/vue-components/tests/unit/components/Lookup.spec.ts
@@ -80,22 +80,6 @@ describe( 'Lookup', () => {
 			expect( wrapper.find( 'input' ).attributes( 'disabled' ) ).toBeTruthy();
 		} );
 
-		it( ':ariaRequired - not required by default', () => {
-			const wrapper = mount( Lookup );
-
-			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'false' );
-		} );
-
-		it( ':ariaRequired - can be required', () => {
-			const wrapper = mount( Lookup, {
-				propsData: {
-					ariaRequired: true,
-				},
-			} );
-
-			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'true' );
-		} );
-
 		it( ':placeholder - can have a placeholder', () => {
 			const placeholder = 'a placeholder';
 			const wrapper = mount( Lookup, {
@@ -159,6 +143,22 @@ describe( 'Lookup', () => {
 				expect( wrapper.findComponent( Input ).props( 'feedbackType' ) ).toStrictEqual( errorType );
 			},
 		);
+
+		it( 'other props - are passed through to the input, except class and style', () => {
+			const wrapper = mount( Lookup, {
+				propsData: {
+					tabindex: 1,
+					ariaRequired: true,
+					class: 'foo',
+					style: 'color: red',
+				},
+			} );
+
+			expect( wrapper.find( 'input' ).attributes( 'tabindex' ) ).toBe( '1' );
+			expect( wrapper.find( 'input' ).attributes( 'aria-required' ) ).toBe( 'true' );
+			expect( wrapper.classes() ).toContain( 'foo' );
+			expect( wrapper.attributes( 'style' ) ).toBe( 'color: red;' );
+		} );
 	} );
 
 	describe( '@events', () => {


### PR DESCRIPTION
Now aria-required can also be handled by this attribute inheritance and no longer needs its own dedicated prop.

Bug: T322686