### PR TITLE
Cherry-pick 'Add aria-controls attribute to LookupInput (#674)'

### DIFF
--- a/vue-components/src/components/LookupInput.vue
+++ b/vue-components/src/components/LookupInput.vue
@@ -14,6 +14,7 @@
 			autocomplete="off"
 			v-bind="$attrs"
 			:aria-activedescendant="keyboardHoverId"
+			:aria-controls="optionsMenuId"
 			:aria-owns="optionsMenuId"
 			aria-autocomplete="list"
 			aria-haspopup="listbox"


### PR DESCRIPTION
This should be set to the same ID as the aria-owns attribute: the input is not only a functional parent of the options menu (aria-owns), but also controls its contents and presence (aria-controls).

Bug: T326681