### PR TITLE
Fix Lookup component scrollbar height after open and closing menu

### DIFF
--- a/vue-components/src/components/OptionsMenu.vue
+++ b/vue-components/src/components/OptionsMenu.vue
@@ -161,7 +161,10 @@ export default Vue.extend( {
 			const maxNumberOfElementsDisplayed = 6;
 			if ( menuItems && menuItems.length > maxNumberOfElementsDisplayed ) {
 				const menuHeight = menuItems[ maxNumberOfElementsDisplayed ].offsetTop - menuItems[ 0 ].offsetTop;
-				this.maxHeight = menuHeight;
+				// See: https://phabricator.wikimedia.org/T325822#9078296
+				if ( menuHeight > 0 ) {
+					this.maxHeight = menuHeight;
+				}
 			} else {
 				this.maxHeight = null;
 			}


### PR DESCRIPTION
Note: this is not reproducible in Wikit, please reproduce in special-new-lexeme. Instructions in the phabricator ticket.

Bug: [T325822](https://phabricator.wikimedia.org/T325822)