### PR TITLE
[WiP] Update node version to 16 in github ci

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install
         run: npm ci
       - name: Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install
         run: npm ci
       - name: Test

--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Cache dependencies
       uses: actions/cache@v3
       id: cache
@@ -70,7 +70,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Restore dependencies
       uses: actions/cache@v3
       with:
@@ -93,7 +93,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Restore dependencies
       uses: actions/cache@v3
       with:
@@ -124,7 +124,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Restore dependencies
       uses: actions/cache@v3
       with:
@@ -155,7 +155,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Restore dependencies
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Checks are failing at [this step](https://github.com/wmde/wikit/actions/runs/5800751927/job/15723582350#step:5:92) in the checks. This error was probably introduced when upgrading github actions that don't support node 12 in [this commit](https://github.com/wmde/wikit/commit/6a7c6cbc18833eb82110b479c3745a5741f96235).

Upgrading to node 16 works partially but now tests are complaing about the deprecation of `lerna bootstrap`.