### PR TITLE
Explicitly use consistent node version in post-merge workflow

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -13,10 +13,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14.x'
 
       - name: Install and Build
         run: |
-          npm install
+          npm ci
           npm run build:storybook
 
       - name: Deploy 🚀


### PR DESCRIPTION
If that is not explicitly set, CI will use whatever comes with `ubuntu_latest` and that is not what we want for this workflow. Node 14 is consistent with what is used in the other workflows. The PR to upgrade these is #684.

This should be merged after #688 and make CI green again on merged branches.