### PR TITLE
Fix cache key for artifact caching

### DIFF
--- a/.github/workflows/test-and-demo.yaml
+++ b/.github/workflows/test-and-demo.yaml
@@ -52,7 +52,7 @@ jobs:
       with:
         path: |
           */dist
-        key: ${{ runner.os }}-${{ hashFiles('*/dist') }}
+        key: ${{ runner.os }}-${{ github.sha }}
     - name: Install
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
@@ -107,7 +107,7 @@ jobs:
       with:
         path: |
           */dist
-        key: ${{ runner.os }}-${{ hashFiles('*/dist') }}
+        key: ${{ runner.os }}-${{ github.sha }}
     - name: Build Storybooks
       run: npm run build:storybook
     - name: Deploy Storybook


### PR DESCRIPTION
When this action runs, `hashFiles('*/dist')` would always return the empty string, because it does not match any files. That means that the cache key would always be identical: `linux-`.

This should be merged after #690