### PR TITLE
Mark Wikit as deprecated in docs

### DIFF
--- a/docs/src/00-doc/01_getting_started.stories.mdx
+++ b/docs/src/00-doc/01_getting_started.stories.mdx
@@ -2,9 +2,13 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Documentation/Getting started" />
 
-# WiKit
+# WiKit (deprecated)
 
-This documents the work on the WiKit product, our Wikidata / Wikibase Design System.
+This documents the deprecated WiKit product, the former Wikidata / Wikibase Design System.
+
+## Deprecation Warning
+
+WiKit **has been deprecated** and will no longer be maintained. For a similar design system and components library for Wikimedia projects, please see [Codex](https://doc.wikimedia.org/codex/latest/).
 
 ## Table of Contents 
 * [Using vue components](#using-vue-components)<br/>


### PR DESCRIPTION
With Wikit no longer being actively maintained, its documentation (in https://wmde.github.io/wikit) should be updated to notify any readers that Wikit is deprecated and that it has been superseded by Codex.

Bug: T382052